### PR TITLE
Remove unused translations

### DIFF
--- a/locales/Danish.lua
+++ b/locales/Danish.lua
@@ -80,7 +80,6 @@ GRML.Danish = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -94,7 +93,6 @@ GRML.Danish = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -123,12 +121,9 @@ GRML.Danish = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -158,7 +153,6 @@ GRML.Danish = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -170,13 +164,9 @@ GRML.Danish = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.Danish = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.Danish = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.Danish = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.Danish = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.Danish = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.Danish = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.Danish = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.Danish = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = true
@@ -560,7 +531,6 @@ GRML.Danish = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.Danish = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.Danish = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.Danish = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.Danish = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.Danish = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -716,8 +672,6 @@ GRML.Danish = function()
     GRM_L["It's almost time to celebrate {name}'s Birthday!"] = true          -- Custom1 is the actual date.  Like "1 Mar '18"
     GRM_L["Unique accounts pull from the server is known to be faulty"] = true
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -726,7 +680,6 @@ GRML.Danish = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -760,31 +713,16 @@ GRML.Danish = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -803,30 +741,15 @@ GRML.Danish = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
-    GRM_L["X = index of minimum rank. Example: 0 = {name} and {num} = {name2}"] = true
-    GRM_L["'g2^X' - Establish minimum sync rank restriction for player details"] = true
-    GRM_L["'g3^X' - Establish minimum sync rank restriction for BAN info"] = true
-    GRM_L["'g4^X' - Establish minimum sync rank restriction for Custom Note info"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -837,7 +760,6 @@ GRML.Danish = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -847,15 +769,12 @@ GRML.Danish = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -921,12 +840,10 @@ GRML.Danish = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -962,7 +879,6 @@ GRML.Danish = function()
 
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -1000,7 +916,6 @@ GRML.Danish = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1040,16 +955,12 @@ GRML.Danish = function()
 
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
 
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1102,8 +1013,6 @@ GRML.Danish = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1166,7 +1075,6 @@ GRML.Danish = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1115,7 @@ GRML.Danish = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1146,6 @@ GRML.Danish = function()
     GRM_L["*Max Export is 500 Log Entries at a Time"] = true
     GRM_L["*Max Export is 500 Members at a Time"] = true
     GRM_L["*Max Export is 500 Former Members at a Time"] = true
-    GRM_L["Log export follows the search and display settings"] = true
     GRM_L["*Export obeys the current log display filters"] = true
     GRM_L["Select Line Range:"] = true
     GRM_L["Select Member Range:"] = true
@@ -1311,7 +1216,6 @@ GRML.Danish = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1238,6 @@ GRML.Danish = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1268,6 @@ GRML.Danish = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1293,6 @@ GRML.Danish = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1320,6 @@ GRML.Danish = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1453,7 +1353,6 @@ GRML.Danish = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1514,7 +1413,6 @@ GRML.Danish = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/Dutch.lua
+++ b/locales/Dutch.lua
@@ -79,7 +79,6 @@ GRML.Dutch = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.Dutch = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.Dutch = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.Dutch = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.Dutch = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -290,13 +280,10 @@ GRML.Dutch = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -329,7 +316,6 @@ GRML.Dutch = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -338,8 +324,6 @@ GRML.Dutch = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -349,10 +333,6 @@ GRML.Dutch = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -360,8 +340,6 @@ GRML.Dutch = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -370,11 +348,6 @@ GRML.Dutch = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -394,7 +367,6 @@ GRML.Dutch = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -463,7 +435,6 @@ GRML.Dutch = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = true
@@ -559,7 +530,6 @@ GRML.Dutch = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -610,7 +580,6 @@ GRML.Dutch = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -642,9 +611,6 @@ GRML.Dutch = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -655,7 +621,6 @@ GRML.Dutch = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -669,20 +634,15 @@ GRML.Dutch = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -702,10 +662,6 @@ GRML.Dutch = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -715,8 +671,6 @@ GRML.Dutch = function()
     GRM_L["It's almost time to celebrate {name}'s Birthday!"] = true          -- Custom1 is the actual date.  Like "1 Mar '18"
     GRM_L["Unique accounts pull from the server is known to be faulty"] = true
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -725,7 +679,6 @@ GRML.Dutch = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -759,31 +712,16 @@ GRML.Dutch = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -802,30 +740,15 @@ GRML.Dutch = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
-    GRM_L["X = index of minimum rank. Example: 0 = {name} and {num} = {name2}"] = true
-    GRM_L["'g2^X' - Establish minimum sync rank restriction for player details"] = true
-    GRM_L["'g3^X' - Establish minimum sync rank restriction for BAN info"] = true
-    GRM_L["'g4^X' - Establish minimum sync rank restriction for Custom Note info"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -836,7 +759,6 @@ GRML.Dutch = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -846,15 +768,12 @@ GRML.Dutch = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -920,12 +839,10 @@ GRML.Dutch = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -961,7 +878,6 @@ GRML.Dutch = function()
 
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -999,7 +915,6 @@ GRML.Dutch = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1039,16 +954,12 @@ GRML.Dutch = function()
 
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
 
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1101,8 +1012,6 @@ GRML.Dutch = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1165,7 +1074,6 @@ GRML.Dutch = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1206,9 +1114,7 @@ GRML.Dutch = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1239,7 +1145,6 @@ GRML.Dutch = function()
     GRM_L["*Max Export is 500 Log Entries at a Time"] = true
     GRM_L["*Max Export is 500 Members at a Time"] = true
     GRM_L["*Max Export is 500 Former Members at a Time"] = true
-    GRM_L["Log export follows the search and display settings"] = true
     GRM_L["*Export obeys the current log display filters"] = true
     GRM_L["Select Line Range:"] = true
     GRM_L["Select Member Range:"] = true
@@ -1311,7 +1216,6 @@ GRML.Dutch = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1238,6 @@ GRML.Dutch = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1268,6 @@ GRML.Dutch = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1293,6 @@ GRML.Dutch = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1320,6 @@ GRML.Dutch = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1453,7 +1353,6 @@ GRML.Dutch = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1514,7 +1413,6 @@ GRML.Dutch = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/English.lua
+++ b/locales/English.lua
@@ -81,7 +81,6 @@ GRML.English = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -95,7 +94,6 @@ GRML.English = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -124,11 +122,8 @@ GRML.English = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -159,7 +154,6 @@ GRML.English = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -171,13 +165,9 @@ GRML.English = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -292,13 +282,10 @@ GRML.English = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -331,7 +318,6 @@ GRML.English = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -340,8 +326,6 @@ GRML.English = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -351,10 +335,6 @@ GRML.English = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -362,8 +342,6 @@ GRML.English = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -372,11 +350,6 @@ GRML.English = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -396,7 +369,6 @@ GRML.English = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -465,7 +437,6 @@ GRML.English = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = true
@@ -561,7 +532,6 @@ GRML.English = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -612,7 +582,6 @@ GRML.English = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -644,9 +613,6 @@ GRML.English = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -657,7 +623,6 @@ GRML.English = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -671,20 +636,15 @@ GRML.English = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -704,10 +664,6 @@ GRML.English = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -717,8 +673,6 @@ GRML.English = function()
     GRM_L["It's almost time to celebrate {name}'s Birthday!"] = true          -- Custom1 is the actual date.  Like "1 Mar '18"
     GRM_L["Unique accounts pull from the server is known to be faulty"] = true
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -727,7 +681,6 @@ GRML.English = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -761,31 +714,16 @@ GRML.English = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -804,26 +742,15 @@ GRML.English = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -834,7 +761,6 @@ GRML.English = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -844,15 +770,12 @@ GRML.English = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -918,12 +841,10 @@ GRML.English = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -959,7 +880,6 @@ GRML.English = function()
 
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -997,7 +917,6 @@ GRML.English = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1037,16 +956,12 @@ GRML.English = function()
 
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
 
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1099,8 +1014,6 @@ GRML.English = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1163,7 +1076,6 @@ GRML.English = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1204,9 +1116,7 @@ GRML.English = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1237,7 +1147,6 @@ GRML.English = function()
     GRM_L["*Max Export is 500 Log Entries at a Time"] = true
     GRM_L["*Max Export is 500 Members at a Time"] = true
     GRM_L["*Max Export is 500 Former Members at a Time"] = true
-    GRM_L["Log export follows the search and display settings"] = true
     GRM_L["*Export obeys the current log display filters"] = true
     GRM_L["Select Line Range:"] = true
     GRM_L["Select Member Range:"] = true
@@ -1308,7 +1217,6 @@ GRML.English = function()
 
     -- 1.85
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1331,7 +1239,6 @@ GRML.English = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1362,7 +1269,6 @@ GRML.English = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1388,7 +1294,6 @@ GRML.English = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
 
@@ -1416,7 +1321,6 @@ GRML.English = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1477,7 +1381,6 @@ GRML.English = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/French.lua
+++ b/locales/French.lua
@@ -79,7 +79,6 @@ GRML.French = function()
     GRM_L["Edit Promo Date"] = "Éditer date"
     GRM_L["Edit Join Date"] = "Éditer date d'entrée"
     GRM_L["Set Promo Date"] = "Définir"
-    GRM_L["In Group"] = "En groupe"                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = "Invitation de groupe"
     GRM_L["No Invite"] = "Pas d'invitation"
     GRM_L["Group Invite"] = "Invitation de groupe"
@@ -93,7 +92,6 @@ GRML.French = function()
     GRM_L["Player Alts"] = "Alts du joueur"
     GRM_L["Add Alt"] = "Ajouter Alt"
     GRM_L["Choose Alt"] = "Choisir Alt"
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = "Maj + Survoler un nom dans la liste fonctionne également"
     GRM_L["Guild Log"] = "Journal de guilde"
     GRM_L["Guild"] = "Guilde"
 
@@ -122,12 +120,9 @@ GRML.French = function()
     GRM_L["Guild Roster Event Log"] = "Journal de guilde"
     GRM_L["Clear Log"] = "Nettoyer journal"
     GRM_L["Really Clear the Guild Log?"] = "Voulez-vous vraiment nettoyer le journal de guilde ?"
-    GRM_L["{name} DEMOTED {name2}"] = "{name} a rétrogradé {name2}"
-    GRM_L["{name} PROMOTED {name2}"] = "{name} a promu {name2}"
     GRM_L["{name} KICKED {name2} from the Guild!"] = "{name} a renvoyé {name2} de la guilde !"
     GRM_L["kicked"] = "renvoyé"
     GRM_L["{name} has Left the guild"] = "{name} a quitté la guilde"
-    GRM_L["{name} INVITED {name2} to the guild."] = "{name} a invité {name2} dans la guilde."
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = "{name} a banni {name2} et tous ses alts liés de la guilde !"
     GRM_L["{name} has BANNED {name2} from the guild!"] = "{name} a banni {name2} de la guilde !"
     GRM_L["Reason Banned:"] = "Raison du ban : "
@@ -157,7 +152,6 @@ GRML.French = function()
     GRM_L["{name} has JOINED the guild!"] = "{name} a rejoint la guilde !"
     GRM_L["Date Left:"] = "Date du départ :"
     GRM_L["{name} has Leveled to {num}"] = "{name} a atteint le niveau {num}"
-    GRM_L["Leveled to"] = "a atteint le niveau"                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = "(+{num} niveaux)"                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = "(+{num} niveau)"                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = "Note publique de {name} ajoutée : \"{custom1}\""           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.French = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = "Grade de guilde renommé de {custom1} en {custom2}"
     GRM_L["{name} has Name-Changed to {name2}"] = "{name} a changé de nom pour {name2}"
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = "{name} est En Ligne après avoir été Inactif pendant {num}"
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = "{name } semble avoir changé de nom mais son nouveau nom est difficile à déterminer"
-    GRM_L["It Could Be One of the Following:"] = "Ce pourrait être l'un des suivants :"
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = "{name} est Hors Ligne depuis {num}. Exclusion recommandée !"
     GRM_L["({num} ago)"] = "de cela"                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = "La guilde {name} a été renommée en \"{name2}\""
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = "{name} célébrera {num} an dans la guilde ! ( {custom1} )"            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = "{name} célébrera {num} ans dans la guilde ! ( {custom1} )"           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = "Promotions"
     GRM_L["Demotions"] = "Rétrogradations"
 
@@ -291,13 +281,10 @@ GRML.French = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = "Désactivation synchronisation des données avec les membres..."
     GRM_L["Display Sync Update Messages"] = "Afficher les messages de mise à jour de la synchronisation"
     GRM_L["Only Sync With Up-to-Date Addon Users"] = "Synchroniser seulement avec les utilisateurs dont l'addon est à jour"
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = "Annoncer seulement les anniversaires si listés comme 'Main'"
     GRM_L["Leveled"] = "Niveau gagné"
-    GRM_L["Min:"] = "Min : "                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = "Inactif"
     GRM_L["resetall"] = "resetall"
     GRM_L["resetguild"] = "resetguild"
-    GRM_L["Notify When Players Request to Join the Guild"] = "Notifier quand des joueurs demandent à rejoindre la guilde"
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = "Changement nom"
     GRM_L["Rank Renamed"] = "Rang renommé"
@@ -330,7 +317,6 @@ GRML.French = function()
     GRM_L["Join Date"] = "Arrivée"
     GRM_L["Promo Date"] = "Promotion"
     GRM_L["Main/Alt"] = "Main/Alt"
-    GRM_L["Click Player to Edit"] = "Cliquez sur un joueur pour modifier"
     GRM_L["Only Show Incomplete Guildies"] = "Afficher seulement fiches incomplètes"
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.French = function()
     GRM_L["(Ver:"] = "(Ver:"                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = "GRM mis à jour"
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = "Configuration de Guild Roster Manager pour {name} pour la première fois."
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = "Réactivation du scan auto des modifications des membres"
-    GRM_L["Reactivating Data Sync..."] = "Réactivation Synchronisation des données..."
     GRM_L["Notification Set:"] = "Notification définie :"
     GRM_L["Report When {name} is ACTIVE Again!"] = "Signaler quand {name} est ACTIF à nouveau !"
     GRM_L["Report When {name} Comes Online!"] = "Signaler quand {name} se connecte !"
@@ -350,10 +334,6 @@ GRML.French = function()
     GRM_L["Player Does Not Have a Time Machine!"] = "Le joueur ne possède pas de machine à voyager dans le temps !"
     GRM_L["Please choose a valid DAY"] = "Merci de choisir un jour valide"
     GRM_L["{name} has been Removed from the Ban List."] = "{name} a été retiré de la liste de bans."
-    GRM_L["{num} Players Have Requested to Join the Guild."] = "{num} joueurs ont demandé à rejoindre la guilde."
-    GRM_L["A Player Has Requested to Join the Guild."] = "Un joueur a demandé à rejoindre la guilde."
-    GRM_L["Click Link to Open Recruiting Window:"] = "Cliquez sur le lien pour ouvrir la fenêtre de recrutement : "
-    GRM_L["Guild Recruits"] = "Postulants"
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = "Recherche de modifications de guilde. Un moment..."
     GRM_L["Breaking current Sync with {name}."] = "Interruption de la synchronisation avec {name}."
     GRM_L["Breaking current Sync with the Guild..."] = "Interruption de la synchronisation avec la guilde..."
@@ -361,8 +341,6 @@ GRML.French = function()
     GRM_L["No Players Currently Online to Sync With..."] = "Aucun joueur en ligne pour synchronisation..."
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = "Aucun utilisateur de GRM actuellement compatible pour une synchronisation totale."
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = "Synchronisation des membres actuellement impossible : le canal de guilde est restreint."
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = "Aucun postulant n'a demandé à rejoindre la guilde."
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = "La liste de postulants est indisponible sans avoir les droits d'invitation."
     GRM_L["Manual Scan Complete"] = "Scan manuel terminé"
     GRM_L["Analyzing guild for the first time..."] = "Analyse de la guilde pour la première fois..."
     GRM_L["Building Profiles on ALL \"{name}\" members"] = "Création du profil des membres de \"{name}\""                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.French = function()
     GRM_L["{name} is now OFFLINE!"] = "{name} est Hors Ligne !"
     GRM_L["{name} is No Longer AFK or Busy!"] = "{name} n'est plus AFK ou Occupé !"
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = "{name} n'est plus AFK ou Occupé mais il s'est déconnecté !"
-    GRM_L["{name} is Already in Your Group!"] = "{name} est déjà dans votre groupe !"
-    GRM_L["GROUP NOTIFICATION:"] = "NOTIFICATION DE GROUPE : "
-    GRM_L["Players Offline:"] = "Joueurs Hors Ligne :"
-    GRM_L["Players AFK:"] = "Joueurs AFK :"
-    GRM_L["40 players have already been invited to this Raid!"] = "40 joueurs ont déjà été invités à ce raid !"
     GRM_L["Player should try to obtain group invite privileges."] = "Le joueur doit obtenir les droits d'invitation au groupe"
     GRM_L["{name}'s saved data has been wiped!"] = "Les données sauvegardées de {name} ont été effacées !"
     GRM_L["Re-Syncing {name}'s Guild Data..."] = "Re-synchronisation des données de guilde de {name}..."
@@ -395,7 +368,6 @@ GRML.French = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = "Lance la re-synchronisation manuelle si la synchronisation est activée"
     GRM_L["Does a one-time manual scan for changes"] = "Effectue une analyse manuelle ponctuelle des modifications"
     GRM_L["Displays current Addon version"] = "Afficher la version actuelle de l'addon"
-    GRM_L["Opens Guild Recruitment Window"] = "Ouvre la fenêtre de recrutement"
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = "AVERTISSEMENT ! Réinitialisation totale, réglages inclus, comme si l'addon venait d'être installé.";
 
     -- General Misc UI
@@ -463,7 +435,6 @@ GRML.French = function()
     GRM_L["sync"] = "sync"                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = "scan"                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = "clearall"                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = "postulant"                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "Chevalier de la mort"
@@ -559,7 +530,6 @@ GRML.French = function()
     GRM_L["Player is Not Currently in a Guild"] = "Le joueur n'est pas dans une guilde actuellement"
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = "|CFFE6CC7FClic|r pour ouvrir GRM"                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = "|CFFE6CC7FClic-droit|r et tirer pour déplacer ce bouton."   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = "|CFFE6CC7FClic-Droit|r pour réinitialiser à 100%"                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = "|CFFE6CC7FClic-droit|r pour synchroniser la date d'entrée avec les alts"
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = "|CFFE6CC7FClic-droit|r pour activer les notifications de changement de statut"
@@ -610,7 +580,6 @@ GRML.French = function()
     GRM_L["{name} has been removed from the database."] = "{name} a été retirée de la base de données."              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = "Vous partagerez toujours vos données avec la guilde mais vous n’acceptez actuellement que les modifications entrantes du grade \"{name}\" ou supérieur."    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = "Limiter, selon le grade, uniquement les données entrantes, pas les sortantes"
     GRM_L["Total Entries: {num}"] = "Entrées totales : {num}"
     GRM_L["Search Filter"] = "Filtre de recherche"
@@ -642,9 +611,6 @@ GRML.French = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = "Vous avez actuellement {num} amis non-Battletag. Pour profiter pleinement de toutes les fonctionnalités de GRM, envisagez de libérer de la place."
-    GRM_L["Clear Space on Friends List to Find Online Status"] = "Nettoyer la liste d'amis pour trouver les statuts En Ligne"
-    GRM_L["Offline"] = "Hors Ligne"
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = "{name} a demandé à rejoindre la guilde et est actuellement EN LIGNE !"
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = "Effacer la ligne {num} ?"
@@ -655,7 +621,6 @@ GRML.French = function()
     GRM_L["Right-Click to Reset to 100%"] = "Clic-droit pour réinitialiser à 100%"
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = "|CFFE6CC7FClic|r pour ouvrir la fenêtre du joueur"
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = "|CFFE6CC7FCtrl-Maj-Clic|r pour chercher le joueur dans le journal"
 
     -- Update 1.1480
@@ -669,20 +634,15 @@ GRML.French = function()
     GRM_L["Sync Custom Notes"] = "Synchroniser les notes personnalisées"
     GRM_L["Default Custom Note Rank Minimum"] = "Grade minimum pour synchroniser notes personnalisées"
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = "Réinitialiser les restrictions pour tous les membres"
-    GRM_L["Reset to Default"] = "Réinitialiser par défaut"
     GRM_L["Reset"] = "Réinitialiser"
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = "|CFF00CCFFSélection par défaut pour tous les joueurs"
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = "Si la synchronisation a été désactivée manuellement pour des membres spécifiques, cela ne l’a PAS activée."
-    GRM_L["Custom note Sync has been reset to default"] = "Synchronisation des notes personnalisées réinitialisée par défaut."
     GRM_L["Click here to set Custom Notes"] = "Cliquer pour ajouter une note personnalisée"
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = "|CFF00CCFFNote personnalisée par défaut :"
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = "|CFFE6CC7FCtrl-Clic-Gauche|r pour réactiver la synchronisation des notes personnalisées pour tous"
-    GRM_L["Custom Note Sync Disabled in Settings"] = "Synchro des notes personnalisées désactivée dans les réglages"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = "{name} a modifié la note personnalisée de {name2} : \"{custom1}\" a été ajouté"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = "{name} a modifié la note personnalisée de {name2} : \"{custom1}\" a été retiré"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = "{name} a modifié la note personnalisée de {name2} : \"{custom1}\" en \"{custom2}\""
     GRM_L["Custom Note"] = "Note personnalisée"
-    GRM_L["Syncing Outgoing Data."] = "Données de synchronisation sortantes."
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = "|CFFE6CC7FClic|r pour modifier la restriction de grade"
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = "|CFFE6CC7FClic|r pour modifier le jour"
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = "|CFFE6CC7FClic|r pour modifier le mois";
@@ -702,10 +662,6 @@ GRML.French = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = "|CFFE6CC7FClic-gauche|r pour modifier la langue"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = "|CFFE6CC7FClic-gauche|r pour modifier le format horaire"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = "|CFFE6CC7FClic-gauche|r pour modifier la police"
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = "Malheureusement, les données de chaque joueur devront être reconfigurées manuellement."
-    GRM_L["{num} custom {custom1} removed that matched text:"] = "{num} {custom1} personnalisée(s) ont retiré le texte correspondant :"                            -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = "notes"
-    GRM_L["Please add specific text, in quotations, to match"] = "Merci d'ajouter un texte spécifique, entre guillemets, pour correspondre"
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = "Vous partagerez encore des données sortantes avec la guilde"
@@ -715,8 +671,6 @@ GRML.French = function()
     GRM_L["It's almost time to celebrate {name}'s Birthday!"] = "Le jour de naissance de {name} approche !"          -- Custom1 is the actual date.  Like "1 Mar '18"
     GRM_L["Unique accounts pull from the server is known to be faulty"] = "Les comptes uniques extraits du serveur sont connus pour être défectueux"
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = "A considérer seulement comme une estimation. Espérons que Blizz corrige cela bientôt"
-    GRM_L["Guild member for over {num} year"] = "Membre de la guilde depuis plus d'{num} an"
-    GRM_L["Guild member for over {num} years"] = "Membre de la guilde depuis plus de {num} ans"   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = "Ajouter des événements à venir au calendrier"
     GRM_L["Player rank unable to add events to calendar"] = "Grade du joueur insuffisant pour ajouter des événements au calendrier"
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = "Les anniversaires, dates de naissance et autres événements peuvent être ajoutés avec une permission"
@@ -725,7 +679,6 @@ GRML.French = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = "Consultez l'onglet \"Utilisateurs Synchronisation\" pour trouver la raison !"
     GRM_L["Time as Member:"] = "Membre depuis :"
     GRM_L["|CFFE6CC7FClick|r to select player event"] = "|CFFE6CC7FClic|r pour sélectionner l'événement du joueur"
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = "|CFFE6CC7FCliquez encore|r pour ouvrir la fenêtre du joueur"
     GRM_L["Timestamp Format:"] = "Format de la date :"
     GRM_L["Hour Format:"] = "Format Horaire :"
     GRM_L["24 Hour"] = "24 heures"
@@ -759,31 +712,16 @@ GRML.French = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = "|CFFE6CC7FClic|r pour trier par promotions les plus anciennes"
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = "|CFFE6CC7FClic|r pour afficher les 'Mains' en premier"
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = "|CFFE6CC7FClic|r pour afficher les 'Alts' en premier"
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = "Profil de {name} en construction. Un moment..."
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = "{num} joueurs demandent à rejoindre votre guilde. Vous ne pouvez plus ajouter que {custom1} ami(s). Pensez à nettoyer vos listes d'amis et de recrutement.";
     GRM_L["{name}'s Alts"] = "Alts de {name}"                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = "En ligne :  {num}/{custom1}"                         -- As in "Online: 3/59"
-    GRM_L["Next"] = "Suivant"                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = "Précédent"                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = "Aucun postulant en ligne."
-    GRM_L["There are currently no more players in that direction."] = "Aucun joueur dans cette direction"
-    GRM_L["You have reached the end of the list"] = "Vous avez atteint la fin de la liste"
-    GRM_L["You have reached the top of the list"] = "Vous avez atteint le début de la liste"
-    GRM_L["Auto Open Window"] = "Affichage automatique"
-    GRM_L["Only if a player is online and you are not in combat"] = "Seulement si un joueur est en ligne et que vous êtes hors combat"
-    GRM_L["Recruit window will open when combat ends."] = "La fenêtre de postulants s'ouvrira à la fin du combat."
     GRM_L["GRM window will open when combat ends."] = "La fenêtre GRM s'ouvrira à la fin du combat."
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = "Cela changera aussi le format <Alt> pour correspondre"
     GRM_L["M"] = "M"                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = "R"           
-    GRM_L["<M>"] = "<M>"                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = "<R>"                                        -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = "Ajouter la mention \"Recruté le\" avec la date."                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = "Recruté le {name}"                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = "Détection automatique GRM ! {name} a rejoint la guilde et sera défini comme 'Main'"            -- Main auto-detect message
 
     -- R1.26
@@ -802,26 +740,15 @@ GRML.French = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true;
     GRM_L["Hard Reset"] = "Hard Reset"
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = "Réinitialisation TOTALE de toutes les données GRM, pour tout le compte.\nLe jeu sera rechargé !"
-    GRM_L["Reject\nAll"] = "Refuser\nTous"                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = "{num} postulants à la guilde ont été refusés"
-    GRM_L["Do you really want to reject all applicants?"] = "Voulez-vous vraiment refuser tous les postulants ?"
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = "Recommander l'exclusion seulement si tous les alts liés excèdent le temps maximal"
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = "Votre chef de guilde a restreint la synchronisation aux {name} ou supérieurs"
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = "Impossible de changer le grade. Le chef de guilde a défini une restriction aux {name} ou supérieurs"     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = "Impossible de changer le grade. Le chef de guilde a défini une restriction de niveau."
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = "Unifier les paramètres de contrôle pour tous les membres avec les commandes 'g#^X'"
-    GRM_L["CONTROL TAGS:"] = "BALISES DE CONTRÔLE"
     GRM_L["Force Settings with Guild Info Tags"] = "Forcer les paramètres avec les balises :"
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = "Avertissement ! Messages système désactivés ! GRM ne peut pas fonctionner correctement sans eux. Vous devez les réactiver dans les réglages du Chat."
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = "Base de données en cours de chargement. GRM s'ouvrira automatiquement une fois l'opération terminée."
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = "Voulez-vous vraiment inviter tous les postulants ?"
-    GRM_L["There are currently 0 players online to invite."] = "Il n'y a aucun joueur en ligne à inviter"
-    GRM_L["It appears all players are now offline."] = "Il semble que tous les joueurs soient Hors Ligne"
-    GRM_L["Invite\nAll"] = "Inviter\nTous"                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = "Inclure un message lors de l'invitation"
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = "Cliquez pour définir un message d'invitation. Appuyez sur Entrée avant d'envoyer l'invitation !"
     GRM_L["The highlighted character is not valid for messages. Please remove."] = "Le caractère en surbrillance n'est pas valide pour les messages. Merci de le retirer."
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = "Certains caractères sont invalides. Merci de retirer les caractères non-alphabétiques."
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = "Macro 'Renvoi' créée. Appuyer sur \"CTRL-MAJ-K\" pour renvoyer tous les Alts de {name}"
@@ -832,7 +759,6 @@ GRML.French = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = "Synchronisation avec {name} effectuée..."
-    GRM_L["Database Still Loading. Please Wait..."] = "Chargement de la base de données. Merci de patienter..."
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = "|CFFE6CC7FClic gauche|r et tirer pour déplacer ce bouton."
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = "|CFFE6CC7FCtrl-Clic gauche|r et tirer pour déplacer ce bouton n'importe où."
     GRM_L["MOTD:"] = "Message du jour"       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -842,15 +768,12 @@ GRML.French = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = "Afficher le tag 'Main' dans le Chat sur les Mains ET sur les Alts"
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = "Invitations envoyées..."
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = "GRM a déplacé les réglages de restrictions de guilde dans l'onglet Infos guilde"
     GRM_L["Please make room for them and re-add."] = "Merci de faire de la pace et de les ajouter à nouveau."
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = "Votre chef de guilde a lancé une réinitialisation de vos données.";
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = "Votre chef de guilde a défini une restriction de synchronisation des bans aux {name} ou supérieurs"
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = "Votre chef de guilde a défini une restriction de synchronisation des notes personnalisées aux {name} ou supérieurs"
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = "Macro 'Inviter tous' créée. Appuyer sur \"CTRL-MAJ-K\" pour inviter tous les postulants en ligne."
     GRM_L["Macro will auto-remove after {num} seconds."] = "Auto-suppression dans {num} secondes."
     GRM_L["UI"] = "UI"
     GRM_L["UI Controls"] = "Réglages UI"
@@ -875,7 +798,6 @@ GRML.French = function()
     GRM_L["{num} is not a valid day of the month! It must be a number between 1 and 31"] = "{num} n'est pas un jour valide du mois ! Ce nombre doit être compris entre 1 et 31"
     GRM_L["{num} is not a valid index of the month of the year! It must be a number between 1 and 12"] = "{num} n'est pas un mois valide de l'année ! Ce nombre doit être compris entre 1 et 12"
     GRM_L["The day cannot be {num}. It must be a number between 1 and 31"] = "Le jour ne peut être {num}. Il doit être compris entre 1 et 31"
-    GRM_L["The month cannot be {num}. must be a number between 1 and 12"] = "Le mois ne peut être {num}. Il doit être compris entre 1 et 12"
     GRM_L["{num} birthdays have been reset."] = "{num} dates de naissance ont été réinitialisées."
     GRM_L["No player was found to have that birthday."] = "Aucun joueur ne correspond à cette date de naissance."
 
@@ -916,12 +838,10 @@ GRML.French = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = "{num} profils de métadonnées en cours de création pour les joueurs précédemment dans la guilde. Les données ont été demandées mais cela peut prendre un moment."                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = "Profil de métadonnées en cours de création pour les joueurs précédemment dans la guilde. Les données ont été demandées mais cela peut prendre un moment."           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = "La synchronisation se déclenchera à nouveau dans un moment pour collecter les dernières données de ces profils."
     GRM_L["Auto-Focus the search box"] = "Focus auto du champ de recherche à l'ouverture du journal"
     GRM_L["This will skip the first time if set to load on logon"] = "Si l'option 'Afficher au démarrage' est activée, le focus se fera à l'ouverture suivante"  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = "Merci d'entrée un niveau valide entre 1 et {num}"
     GRM_L["Player's Main: {name}"] = "'Main' du joueur : {name}"
-    GRM_L["Player's main no longer in the guild: {name}"] = "'Main' du joueur qui n'est plus dans la guilde : {name}"
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -957,7 +877,6 @@ GRML.French = function()
 
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -995,7 +914,6 @@ GRML.French = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1035,16 +953,12 @@ GRML.French = function()
 
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1097,8 +1011,6 @@ GRML.French = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1161,7 +1073,6 @@ GRML.French = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1204,9 +1115,7 @@ GRML.French = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1237,7 +1146,6 @@ GRML.French = function()
     GRM_L["*Max Export is 500 Log Entries at a Time"] = true
     GRM_L["*Max Export is 500 Members at a Time"] = true
     GRM_L["*Max Export is 500 Former Members at a Time"] = true
-    GRM_L["Log export follows the search and display settings"] = true
     GRM_L["*Export obeys the current log display filters"] = true
     GRM_L["Select Line Range:"] = true
     GRM_L["Select Member Range:"] = true
@@ -1308,7 +1216,6 @@ GRML.French = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1331,7 +1238,6 @@ GRML.French = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1362,7 +1268,6 @@ GRML.French = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1388,7 +1293,6 @@ GRML.French = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1416,7 +1320,6 @@ GRML.French = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1477,7 +1380,6 @@ GRML.French = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/German.lua
+++ b/locales/German.lua
@@ -79,7 +79,6 @@
         GRM_L["Edit Promo Date"] = "Beförderungsdatum\nändern"
         GRM_L["Edit Join Date"] = "Beitrittsdatum\nändern"
         GRM_L["Set Promo Date"] = "Beförderungsdatum\nsetzen"
-        GRM_L["In Group"] = "in Gruppe"                            -- Context: "Player is already In Group with you"
         GRM_L["Group Invite"] = "Gruppeneinladung"
         GRM_L["No Invite"] = "Keine Einladung"
         GRM_L["Group Invite"] = "Gruppeneinladung"
@@ -93,7 +92,6 @@
         GRM_L["Player Alts"] = "Twinks"
         GRM_L["Add Alt"] = "Twink hinzufügen"
         GRM_L["Choose Alt"] = "Twink auswählen"
-        GRM_L["Shift-Mouseover Name On Roster Also Works"] = "Shift-Mouseover über die Namen im Roster funktioniert auch"
         GRM_L["Guild Log"] = "Guild Log"
         GRM_L["Guild"] = "Gilde"
     
@@ -122,12 +120,9 @@
         GRM_L["Guild Roster Event Log"] = "Guild Roster Event Verlauf"
         GRM_L["Clear Log"] = "Verlauf löschen"
         GRM_L["Really Clear the Guild Log?"] = "Gildenverlauf wirklich löschen?"
-        GRM_L["{name} DEMOTED {name2}"] = "{name} hat {name2} degradiert"
-        GRM_L["{name} PROMOTED {name2}"] = "{name} hat {name2} befördert"
         GRM_L["{name} KICKED {name2} from the Guild!"] = "{name} hat {name2} aus der Gilde geworfen!"
         GRM_L["kicked"] = "geworfen"
         GRM_L["{name} has Left the guild"] = "{name} hat die Gilde verlassen"
-        GRM_L["{name} INVITED {name2} to the guild."] = "{name} hat {name2} in die Gilde eingeladen"
         GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = "{name} hat {name2} und alle verbundenen Twinks aus der Gilde VERBANNT!"
         GRM_L["{name} has BANNED {name2} from the guild!"] = "{name} hat {name2} aus der Gilde VERBANNT!"
         GRM_L["Reason Banned:"] = "Bann-Grund:"
@@ -157,7 +152,6 @@
         GRM_L["{name} has JOINED the guild!"] = "{name} ist der Gilde BEIGETRETEN"
         GRM_L["Date Left:"] = "Austrittsdatum:"
         GRM_L["{name} has Leveled to {num}"] = "{name} hat Level {num} erreicht"
-        GRM_L["Leveled to"] = "erreicht Level"                                            -- For parsing the message, please include the string found in previous "has leveled to" message
         GRM_L["(+{num} levels)"] = "(+{num} Level)"                                         -- Context: Person gained more than one level, hence the plural
         GRM_L["(+{num} level)"] = "(+{num} Level)"                                          -- Context: Person gains a level, just one level.
         GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = "Öffentliche Notiz von {name}: \"{custom1}\" hinzugefügt"           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@
         GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = "Gildenrang {custom1} wurde umbenannt zu {custom2}"
         GRM_L["{name} has Name-Changed to {name2}"] = "Spieler {name} hat seinen Namen zu {name2} geändert"
         GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = "Spieler {name} kam ONLINE, nachdem er für {num} INAKTIV war"
-        GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = "Spieler {name} scheint seinen Namen geändert zu haben, aber der neue Name kann nicht eindeutig bestimmt werden"
-        GRM_L["It Could Be One of the Following:"] = "Es könnte einer der folgenden sein:"
         GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = "{name} war für {num} OFFLINE. Kick empfohlen!"
         GRM_L["({num} ago)"] = "vor {num}"                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
         GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = "Der Gildenname {name} wurde in \"{name2}\" geändert."
-        GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = "{name} ist seit {num} Jahr in der Gilde!"            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-        GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = "{name} ist seit {num} Jahren in der Gilde!"           -- Same thing but PLURAL - "years" in stead of "year"
         GRM_L["Promotions"] = "Beförderungen"
         GRM_L["Demotions"] = "Degradierungen"
     
@@ -291,13 +281,10 @@
         GRM_L["Deactivating Data SYNC with Guildies..."] = "Daten teilen DEAKTIVIEREN"
         GRM_L["Display Sync Update Messages"] = "Update-Meldungen für GRM anzeigen"
         GRM_L["Only Sync With Up-to-Date Addon Users"] = "Nur mit Mitgliedern synchronisieren, die die aktuelle Version von GRM haben"
-        GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = "Nur Jahrestage von 'Mains' anzeigen"
         GRM_L["Leveled"] = "Level"
-        GRM_L["Min:"] = "Min:"                                    -- Context: As in, the Minimum level to report or announce when player levels up
         GRM_L["Inactive Return"] = "wieder aktiv"
         GRM_L["resetall"] = "resetall"
         GRM_L["resetguild"] = "resetguild"
-        GRM_L["Notify When Players Request to Join the Guild"] = "Anzeigen, wenn die Gilde offene Bewerbungen hat"
         --Side chat/log controls - Of note, limited spacing
         GRM_L["Name Change"] = "Namensänderung"
         GRM_L["Rank Renamed"] = "Rang umbenannt"
@@ -318,9 +305,6 @@
         GRM_L["Main"] = "Main"
         GRM_L["Main or Alt?"] = "Main oder Twink?"
         GRM_L["Alt"] = "Twink"
-        GRM_L["Total Incomplete:"] = "Gesamt unvollständig"
-        GRM_L["Mains:"] = "Mains:"                                                                              -- Context: Number of "main" toons
-        GRM_L["Unique Accounts:"] = "Accounts:"
         GRM_L["Total Incomplete: {num} / {custom1}"] = "Gesamt unvollständig {num} / {custom1}"                 -- Context: Total Incomeplete: 50 / 100    (50 out of 100)
         GRM_L["Mains:\n{num}"] = "Mains:\n{num}"                                                                  -- Context: Number of "main" toons
         GRM_L["Unique Accounts:\n{num}"] = "Accounts:\n{num}"
@@ -333,7 +317,6 @@
         GRM_L["Join Date"] = "Beitritt"
         GRM_L["Promo Date"] = "Beförderung"
         GRM_L["Main/Alt"] = "Main/Twink"
-        GRM_L["Click Player to Edit"] = "Klicke auf einen Spieler zum Ändern"
         GRM_L["Only Show Incomplete Guildies"] = "Nur unvollständige Einträge zeigen"
     
         -- ADDON SYSTEM MESSAGES
@@ -342,8 +325,6 @@
         GRM_L["(Ver:"] = "Version:"                                                               -- Ver: is short for Version:
         GRM_L["GRM Updated:"] = "GRM aktualisiert:"
         GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = "Erstes Konfigurieren von Guild Roster Manager für {name}"
-        GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = "Reaktivieren von Auto-Scan für Gildenmitgliederänderungen"
-        GRM_L["Reactivating Data Sync..."] = "Reaktiviere Daten-Synchronisation"
         GRM_L["Notification Set:"] = "Benachrichtigung eingestellt:"
         GRM_L["Report When {name} is ACTIVE Again!"] = "Meldung, wenn {name} nicht mehr AFK ist!"
         GRM_L["Report When {name} Comes Online!"] = "Meldung, wenn {name} online kommt!"
@@ -353,10 +334,6 @@
         GRM_L["Player Does Not Have a Time Machine!"] = "Spieler hat keine Zeitmaschine!"
         GRM_L["Please choose a valid DAY"] = "Bitte einen gültigen TAG wählen"
         GRM_L["{name} has been Removed from the Ban List."] = "{name} wurde von der Bann-Liste entfernt."
-        GRM_L["{num} Players Have Requested to Join the Guild."] = "{num} Spieler haben eine Gildenanfrage gesendet."
-        GRM_L["A Player Has Requested to Join the Guild."] = "Ein Spieler hat eine Gildenanfrage gesendet."
-        GRM_L["Click Link to Open Recruiting Window:"] = "Hier klicken, um das Bewerbungsfenster zu öffnen"
-        GRM_L["Guild Recruits"] = "Bewerbungen"
         GRM_L["Scanning for Guild Changes Now. One Moment..."] = "Scanne nach Gildenänderungen. Bitte warten..."
         GRM_L["Breaking current Sync with {name}."] = "Breche Synchronisation mit {name} ab."
         GRM_L["Breaking current Sync with the Guild..."] = "Breche Gildensynchronisation ab..."
@@ -364,8 +341,6 @@
         GRM_L["No Players Currently Online to Sync With..."] = "Es sind keine Spieler online, mit denen du synchronisieren kannst."
         GRM_L["No Addon Users Currently Compatible for FULL Sync."] = "Es sind keine kompatiblen Addonnutzer online, mit denen du synchronisieren kannst."
         GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = "Synchronisation nicht möglich! Gildenchat ist eingeschränkt."
-        GRM_L["There are No Current Applicants Requesting to Join the Guild."] = "Keine Bewerbungen"
-        GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = "Die Seite für Gildenbewerbungen ist nicht sichtbar, wenn du keine Rechte zum Einladen hast."
         GRM_L["Manual Scan Complete"] = "Manueller Scan abgeschlossen"
         GRM_L["Analyzing guild for the first time..."] = "Analysiere Gilde das erste Mal..."
         GRM_L["Building Profiles on ALL \"{name}\" members"] = "Erstelle Profile für ALLE \"{name}\" Mitglieder"                 -- {name} will be the Guild Name, for context
@@ -374,11 +349,6 @@
         GRM_L["{name} is now OFFLINE!"] = "{name} ist jetzt OFFLINE!"
         GRM_L["{name} is No Longer AFK or Busy!"] = "{name} ist nicht mehr AFK!"
         GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = "{name} ist nicht mehr AFK, nun aber OFFLINE!"
-        GRM_L["{name} is Already in Your Group!"] = "{name} ist bereits in deiner Gruppe!"
-        GRM_L["GROUP NOTIFICATION:"] = "Gruppenbenachrichtigung:"
-        GRM_L["Players Offline:"] = "Offline:"
-        GRM_L["Players AFK:"] = "AFK:"
-        GRM_L["40 players have already been invited to this Raid!"] = "Es sind bereits 40 Spieler in der Raidgruppe!"
         GRM_L["Player should try to obtain group invite privileges."] = "Du hast keine Rechte, um jemanden einzuladen."
         GRM_L["{name}'s saved data has been wiped!"] = "Die gespeicherten Daten von {name} wurden gelöscht!"
         GRM_L["Re-Syncing {name}'s Guild Data..."] = "Wiederherstellen der Daten von {name}"
@@ -398,7 +368,6 @@
         GRM_L["Triggers manual re-sync if sync is enabled"] = "Starte manuelle Synchronisation"
         GRM_L["Does a one-time manual scan for changes"] = "Startet einmaligen Scan nach Änderungen"
         GRM_L["Displays current Addon version"] = "Zeigt installierte Addon-Version"
-        GRM_L["Opens Guild Recruitment Window"] = "Öffnet Fenster für Bewerbungen"
         GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = "WARNUNG! Komplette Löschung ALLER DATEN inklusive Einstellungen. Als ob das Addon gerade installiert wurde.";
     
         -- General Misc UI
@@ -466,7 +435,6 @@
         GRM_L["sync"] = "sync"                                 -- Context: "sync" the data between players one time now.
         GRM_L["scan"] = "scan"                                 -- Context: "scan" for guild roster changes one time now.
         GRM_L["clearall"] = "clearall"                         -- Context: In regards, "Clear All" saved data
-        GRM_L["recruit"] = "bewerber"                          -- Context: Open the roster "recruit" window where people request to join guild
     
         -- CLASSES
         GRM_L["Deathknight"] = "Todesritter"
@@ -562,7 +530,6 @@
         GRM_L["Player is Not Currently in a Guild"] = "Spieler ist momentan in keiner Gilde"
         -- tooltips
         GRM_L["|CFFE6CC7FClick|r to open GRM"] = "|CFFE6CC7FKlicken|r, um GRM zu öffnen"                           -- Please maintain the color coding
-        GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = "|CFFE6CC7FRechtsklicken|r und ziehen, um diesen Knopf zu verschieben"   -- Likewise, maintain color coding
         GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = "|CFFE6CC7FRechtsklicken|r, um auf 100% zurückzusetzen"                -- for the Options slider tooltip
         GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = "|CFFE6CC7FRechtsklicken|r, um Beitrittsdatum auf alle Twinks zu übertragen"
         GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = "|CFFE6CC7FRechtsklicken|r, um eine Benachrichtigung zu erhalten, wenn der Status sich ändert"
@@ -613,7 +580,6 @@
         GRM_L["{name} has been removed from the database."] = "{name} wurde aus der Datenbank gelöscht."              -- The Guild Name has been removed from the database
     
         -- update 1.141
-        GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = "Du wirst weiterhin deine Daten mit der Gilde teilen, aber du bekommst nur Daten von Rang \"{name}\" oder höher"    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
         GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = "Begrenze nur eingehende Spielerdaten mit dem Rang, nicht ausgehende"
         GRM_L["Total Entries: {num}"] = "Einträge: {num}"
         GRM_L["Search Filter"] = "Suche"
@@ -645,9 +611,6 @@
     
         -- update 1.145
         GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = "Du hast momentan {num} Freunde (nicht Battle-net Freunde!). Um alle Funktionen von GRM nutzen zu können, musst du bitte einen Freund entfernen."
-        GRM_L["Clear Space on Friends List to Find Online Status"] = "Bitte mache Platz auf deiner Freundesliste, um den Online-Status von Bewerbern zu prüfen"
-        GRM_L["Offline"] = "Offline"
-        GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = "{name} hat sich bei der Gilde beworben und ist gerade ONLINE!"
     
         -- Update 1.146
         GRM_L["Really Clear line {num}?"] = "Wirklich Zeile {num} löschen?"
@@ -658,7 +621,6 @@
         GRM_L["Right-Click to Reset to 100%"] = "Rechtsklicken, um auf 100% zurückzusetzen"
     
         -- Update 1.147
-        GRM_L["|CFFE6CC7FClick|r to open Player Window"] = "|CFFE6CC7FKlicken|r, um Spielerfenster zu öffnen"
         GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = "|CFFE6CC7FSTRG-Shift-Klicken|r, um das Log nach diesem Spieler zu durchsuchen"
     
         -- Update 1.148
@@ -672,20 +634,15 @@
         GRM_L["Sync Custom Notes"] = "Teile eigene Notizen"
         GRM_L["Default Custom Note Rank Minimum"] = "Mindestrang zum Teilen:"
         GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = "Setze Beschränkungen für ALLE Mitglieder auf Standard zurück"
-        GRM_L["Reset to Default"] = "Auf Standard zurücksetzen"
         GRM_L["Reset"] = "zurücksetzen"
         GRM_L["|CFF00CCFFDefault Selection For All Players"] = "|CFF00CCFFStandardauswahl für alle Spieler"
-        GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = "Wenn der Sync für einzelne Mitglieder deaktiviert wurde, wird dies sie NICHT aktivieren."
-        GRM_L["Custom note Sync has been reset to default"] = "Eigene Notizen-Sync wurde auf Standard zurückgesetzt"
         GRM_L["Click here to set Custom Notes"] = "Klicke, um Eigene Notizen einzutragen"
         GRM_L["|CFF00CCFFCustom Note Defaults:"] = "|CFF00CCFFEigene Notizen Einstellungen:"
         GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = "|CFFE6CC7FLINKS-Klicken|r, um Sync-Einstellung für eigene Notizen zurückzusetzen"
-        GRM_L["Custom Note Sync Disabled in Settings"] = "Eigene Notizen-Sync ist deaktiviert"
         GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = "{name} hat die eigenen Notizen von {name2} geändert: \"{custom1}\" hinzugefügt"
         GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = "{name} hat die eigenen Notizen von {name2} geändert: \"{custom1}\" gelöscht"
         GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = "{name} hat die eigenen Notizen von {name2} geändert: \"{custom1}\" geändert zu \"{custom2}\""
         GRM_L["Custom Note"] = "Eigene Notiz"
-        GRM_L["Syncing Outgoing Data."] = "Teile ausgehende Daten."
         GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = "|CFFE6CC7FKlicken|r, um Rang-Beschränkungen zu ändern"
         GRM_L["|CFFE6CC7FClick|r to Change Day"] = "|CFFE6CC7FKlicken|r, um Tag zu ändern"
         GRM_L["|CFFE6CC7FClick|r to Change Month"] = "|CFFE6CC7FKlicken|r, um Monat zu ändern";
@@ -705,10 +662,6 @@
         GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = "|CFFE6CC7FKlicken|r, um die Sprache zu ändern"
         GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = "|CFFE6CC7FKlicken|r, um Anzeigeformat zu ändern"
         GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = "|CFFE6CC7FKlicken|r, um die Schriftart zu ändern"
-        GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = "Unglücklicherweise müssen alle Spielerdaten manuell neu eingestellt werden."
-        GRM_L["{num} custom {custom1} removed that matched text:"] = "Es wurden {num} Eigene {custom1} gelöscht, die den Text enthielten:"                           -- custom1 = "note" or the plural "notes"
-        GRM_L["notes"] = "Notizen"
-        GRM_L["Please add specific text, in quotations, to match"] = "Bitte füge einen Text in Anführungszeichen ein, um zu suchen"
     
         -- R1.1490
         GRM_L["You will still share some outgoing data with the guild"] = "Du teilst weiterhin ausgehende Daten mit der Gilde"
@@ -720,8 +673,6 @@
         GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = "Nutze diese Zahl nur als Schätzung. Wir hoffen auf einen Fix von Blizz"
         GRM_L["{name}'s Anniversary!"] = "Jahrestag von {name}!"
         GRM_L["{name}'s Birthday!"] = "Geburtstag von {name}!"
-        GRM_L["Guild member for over {num} year"] = "Gildenmitglied seit über {num} Jahr"
-        GRM_L["Guild member for over {num} years"] = "Gildenmitglied seit über {num} Jahren"  -- the plural version!
         GRM_L["Add Upcoming Events to the Calendar"] = "Füge anstehende Ereignisse dem Kalender hinzu"
         GRM_L["Player rank unable to add events to calendar"] = "Gildenrang zu niedrig, um Ereignisse im Kalender anzulegen"
         GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = "Jahrestage, Geburtstage und andere Ereignisse können mit Erlaubnis angelegt werden"
@@ -730,7 +681,6 @@
         GRM_L["Check the \"Sync Users\" tab to find out why!"] = "Schaue in den \"Sync-Tab\", um herauszufinden, warum"
         GRM_L["Time as Member:"] = "Zeit als Mitglied:"
         GRM_L["|CFFE6CC7FClick|r to select player event"] = "|CFFE6CC7FKlicken|r, um Spieler-Event auszuwählen"
-        GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = "|CFFE6CC7FErneut klicken|r, um Spielerfenster zu öffnen"
         GRM_L["Timestamp Format:"] = "Datumsformat:"
         GRM_L["Hour Format:"] = "Zeitformat:"
         GRM_L["24 Hour"] = "24 Stunden"
@@ -764,31 +714,16 @@
         GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = "|CFFE6CC7FKlicke|r, um Älteste Beförderungen oben zu sehen"
         GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = "|CFFE6CC7FKlicke|r, um alle Mains zuerst zu sehen"
         GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = "|CFFE6CC7FKlicke|r, um alle Twinks zuerst zu sehen"
-        GRM_L["{name}'s Profile is Being Built. One Moment..."] = "Profil von {name} wird erstellt. Einen Moment..."
-        GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = "Deine Gilde hat {num} neue Anfragen. Du hast aber nur Plätze für {custom1} neue Freunde. Bitte mache Platz auf deiner Freundesliste, um den Online-Status von Bewerbern zu prüfen"
         GRM_L["{name}'s Alts"] = "Twinks von {name}"                                            -- Like "Arkaan's Alts"
-        GRM_L["Online:  {num}/{custom1}"] = "Online: {num}/{custom1}"                           -- As in "Online: 3/59"
-        GRM_L["Next"] = "Nächster"                                                              -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-        GRM_L["Previous"] = "Voriger"                                                           -- Same context as the "next" except this one goes back to the one before.
-        GRM_L["There are currently no ONLINE recruits."] = "Momentan sind keine Bewerber online."
-        GRM_L["There are currently no more players in that direction."] = "Es gibt keine Spieler mehr in dieser Richtung."
-        GRM_L["You have reached the end of the list"] = "Du hast das Ende der Liste erreicht"
-        GRM_L["You have reached the top of the list"] = "Du hast den Anfang der Liste erreicht"
-        GRM_L["Auto Open Window"] = "Fenster automatisch öffnen"
-        GRM_L["Only if a player is online and you are not in combat"] = "Nur, wenn ein Spieler online ist und du nicht im Kampf bist"
-        GRM_L["Recruit window will open when combat ends."] = "Anfragen-Fenster wird geöffnet, wenn der Kampf zu Ende ist."
         GRM_L["GRM window will open when combat ends."] = "GRM wird geöffnet, wenn der Kampf zu Ende ist."
     
         -- R1.24
         GRM_L["This also will change the <Alt> format to match"] = true
         GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
         GRM_L["A"] = true           
-        GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-        GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
     
         -- R1.25
         GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-        GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
         GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
     
         -- R1.26
@@ -807,26 +742,15 @@
         GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
         GRM_L["Hard Reset"] = true
         GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-        GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-        GRM_L["{num} Applicants to the Guild have been denied"] = true
-        GRM_L["Do you really want to reject all applicants?"] = true
         GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
         GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
         GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
         GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-        GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-        GRM_L["CONTROL TAGS:"] = true
         GRM_L["Force Settings with Guild Info Tags"] = true
         GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
         GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
     
         -- R1.29
-        GRM_L["Do you really want to invite all applicants?"] = true
-        GRM_L["There are currently 0 players online to invite."] = true
-        GRM_L["It appears all players are now offline."] = true
-        GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-        GRM_L["Include Message When Sending Invite"] = true
-        GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
         GRM_L["The highlighted character is not valid for messages. Please remove."] = true
         GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
         GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -837,7 +761,6 @@
     
         -- R1.30
         GRM_L["Sync With {name} is Complete..."] = true
-        GRM_L["Database Still Loading. Please Wait..."] = true
         GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
         GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
         GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -847,15 +770,12 @@
         GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
     
         -- R1.32
-        GRM_L["Invites Currently Being Sent..."] = true
         GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
         GRM_L["Please make room for them and re-add."] = true
-        GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
         GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
         GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
     
         -- R1.33
-        GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
         GRM_L["Macro will auto-remove after {num} seconds."] = true
         GRM_L["UI"] = true
         GRM_L["UI Controls"] = true
@@ -922,12 +842,10 @@
         -- R1.41
         GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
         GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-        GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
         GRM_L["Auto-Focus the search box"] = true
         GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
         GRM_L["Please enter a valid level between 1 and {num}"] = true
         GRM_L["Player's Main: {name}"] = true
-        GRM_L["Player's main no longer in the guild: {name}"] = true
         
         -- R1.43
         GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -963,7 +881,6 @@
     
         -- 1.56
         -- More slash commands
-        GRM_L["recruits"] = true 
         GRM_L["kick"] = true
         GRM_L["ban"] = true
         GRM_L["audit"] = true
@@ -1001,7 +918,6 @@
         GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
         GRM_L["|CFFE6CC7FClick|r to select player"] = true
         GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-        GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
         GRM_L["Only Show Players With Incomplete Status"] = true
         GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
         GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1041,16 +957,12 @@
         
         -- 1.57
         GRM_L["Full Log Message:"] = true
-        GRM_L["Public Notes"] = true
-        GRM_L["Officer Notes"] = true
-        GRM_L["Custom Notes"] = true
         GRM_L["Log Entry Tooltip"] = true
         GRM_L["1 entry has been removed from the log"] = true
         GRM_L["{num} entries have been removed from the log"] = true
         
         -- 1.58
         GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-        GRM_L["Using the Old Guild Roster Interface instead"] = true
         
         -- 1.59
         GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1103,8 +1015,6 @@
         GRM_L["No Current Names to Add"] = true
         GRM_L["No Names to Add to the Macro"] = true
         GRM_L["Hot Key: {name}"] = true
-        GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-        GRM_L["Press the Hot-key {num} times to complete all actions"] = true
         GRM_L["Permissions"] = true
         GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
         GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1167,7 +1077,6 @@
         -- CLASSIC
         GRM_L["Social"] = true
         GRM_L["Roster"] = true
-        GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
         GRM_L["Feature is disabled in WoW Classic"] = true
         GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
         GRM_L["There is no calendar to add events to"] = true
@@ -1211,9 +1120,7 @@
         GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
         GRM_L["No officer online to set {name}'s note"] = true
         GRM_L["No officer is currently online to update your note"] = true
-        GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
         GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-        GRM_L["'!note' trigger has been globally enabled"] = true
         GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
         GRM_L["'!note' trigger has been globally ENABLED"] = true
         GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1244,7 +1151,6 @@
         GRM_L["*Max Export is 500 Log Entries at a Time"] = true
         GRM_L["*Max Export is 500 Members at a Time"] = true
         GRM_L["*Max Export is 500 Former Members at a Time"] = true
-        GRM_L["Log export follows the search and display settings"] = true
         GRM_L["*Export obeys the current log display filters"] = true
         GRM_L["Select Line Range:"] = true
         GRM_L["Select Member Range:"] = true
@@ -1315,7 +1221,6 @@
     
         -- 1.84
         GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-        GRM_L["{name} Rule {num}"] = true
         GRM_L["Apply Only to Selected Ranks"] = true
         GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
         GRM_L["No player data found, recommend full removal."] = true
@@ -1338,7 +1243,6 @@
         GRM_L["Join Header"] = true;
         GRM_L["ReJoin Header"] = true;
         GRM_L["!note Control"] = true
-        GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
         GRM_L["You need to clear {num} characters to fit the control tags"] = true
         GRM_L["A new format exists for global settings controls."] = true
         GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1369,7 +1273,6 @@
     
         -- R1.87
         GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-        GRM_L["Edit Custom Rule"] = true
         GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
         GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
         GRM_L["Edit"] = true
@@ -1395,7 +1298,6 @@
         GRM_L["Note match: {name}"] = true                                  -- Same
         GRM_L["Matching Rank"] = true                                       -- ''
         GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-        GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
         GRM_L["|CFFE6CC7FClick|r to Change"] = true
         GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
         
@@ -1423,7 +1325,6 @@
         GRM_L["Enable Module"] = true
         GRM_L["Show Interactable Distance Indicator"] = true
         GRM_L["No GRM Modules Currently Installed"] = true
-        GRM_L["Recruitment"] = true
         GRM_L["Pending Feature"] = true
         GRM_L["Custom Color"] = true
         GRM_L["{name} is listed as the Main"] = true
@@ -1487,7 +1388,6 @@
         GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
         GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
         GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-        GRM_L["Guild Rep: {name}"] = true
         GRM_L["Guild Rep:"] = true
         GRM_L["Guild Rep lower than {name}"] = true
         GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/Italian.lua
+++ b/locales/Italian.lua
@@ -79,7 +79,6 @@ GRML.Italian = function()
 	GRM_L["Edit Promo Date"] = "Imposta"
 	GRM_L["Edit Join Date"] = "Modifica data"
 	GRM_L["Set Promo Date"] = "Modifica data"
-	GRM_L["In Group"] = "In gruppo"                            -- Context: "Player is already In Group with you"
 	GRM_L["Group Invite"] = "Invita in gruppo"
 	GRM_L["No Invite"] = "Nessun invito"
 	GRM_L["Group Invite"] = "Invita in gruppo"
@@ -93,7 +92,6 @@ GRML.Italian = function()
 	GRM_L["Player Alts"] = "Alt del Giocatore"
 	GRM_L["Add Alt"] = "Aggiungi Alt"
 	GRM_L["Choose Alt"] = "Scegli Alt"
-	GRM_L["Shift-Mouseover Name On Roster Also Works"] = "Puoi anche usare Shift-Mouseover sul nome nell'elenco"
 	GRM_L["Guild Log"] = "Registro di Gilda"
 	GRM_L["Guild"] = "Gilda"
 
@@ -122,12 +120,9 @@ GRML.Italian = function()
 	GRM_L["Guild Roster Event Log"] = "Registro Eventi"
 	GRM_L["Clear Log"] = "Pulisci Registro" -- Maybe "Cancella registro" is better?
 	GRM_L["Really Clear the Guild Log?"] = "Vuoi davvero cancellare il Registro di Gilda?"
-	GRM_L["{name} DEMOTED {name2}"] = "{name} RETROCESSO a {name2}"
-	GRM_L["{name} PROMOTED {name2}"] = "{name} PROMOSSO a {name2}"
 	GRM_L["{name} KICKED {name2} from the Guild!"] = "{name} ha RIMOSSO {name2} dalla Gilda!"
 	GRM_L["kicked"] = "rimosso"
 	GRM_L["{name} has Left the guild"] = "{name} ha lasciato la Gilda"
-	GRM_L["{name} INVITED {name2} to the guild."] = "{name} ha invitato {name2} nella Gilda"
 	GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = "{name} ha bannato {name2} e tutti gli Alt collegati dalla Gilda!"
 	GRM_L["{name} has BANNED {name2} from the guild!"] = "{name} ha bannato {name2} dalla gilda!"
 	GRM_L["Reason Banned:"] = "Bannato per:"
@@ -157,7 +152,6 @@ GRML.Italian = function()
 	GRM_L["{name} has JOINED the guild!"] = "{name} si è unito alla gilda!"
 	GRM_L["Date Left:"] = "Data di uscita:"
 	GRM_L["{name} has Leveled to {num}"] = "{name} è salito al {num}"
-	GRM_L["Leveled to"] = "Salito al"                                             -- For parsing the message, please include the string found in previous "has leveled to" message
 	GRM_L["(+{num} levels)"] = "(+{num} livelli)"                                        -- Context: Person gained more than one level, hence the plural
 	GRM_L["(+{num} level)"] = "(+{num} livello)"                                          -- Context: Person gains a level, just one level.
 	GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = "Nota Pubblica \"{custom1}\" per {name} aggiunta"          -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.Italian = function()
 	GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = "Grado di gilda rinominato da {custom1} a {custom2}"
 	GRM_L["{name} has Name-Changed to {name2}"] = "{name} ha cambiato nome in {name2}"
 	GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = "{name} è tornato Online dopo essere stato Inattivo per {num}"
-	GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = "Sembra che {name} abbia cambiato nome, ma il nuovo nome è difficile da determinare"
-	GRM_L["It Could Be One of the Following:"] = "Potrebbe essere uno/a dei/delle seguenti:"
 	GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = "{name} è Offline da {num}. Consigliata Rimozione dalla Gilda"
 	GRM_L["({num} ago)"] = "({num} fa)"                                              -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
 	GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = "Il nome della Gilda è stato cambiato da {name} a \"{name2}\""
-	GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = "{name} celebrerà {num} anno in Gilda! ( {custom1} )"            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-	GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = "{name} celebrerà {num} anni in Gilda! ( {custom1} )"           -- Same thing but PLURAL - "years" in stead of "year"
 	GRM_L["Promotions"] = "Promozioni"
 	GRM_L["Demotions"] = "Retrocessioni"
 
@@ -291,13 +281,10 @@ GRML.Italian = function()
 	GRM_L["Deactivating Data SYNC with Guildies..."] = "Disattivazione Sincronizzazione con i gildani"
 	GRM_L["Display Sync Update Messages"] = "Visualizza i messaggi di aggiornamento della Sincronizzazione"
 	GRM_L["Only Sync With Up-to-Date Addon Users"] = "Sincronizza solo con utenti che hanno l'Add-on aggiornato"
-	GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = "Annuncia solo gli anniversari dei \"Main\""
 	GRM_L["Leveled"] = "Livelli"
-	GRM_L["Min:"] = "Min:"                                    -- Context: As in, the Minimum level to report or announce when player levels up
 	GRM_L["Inactive Return"] = "Ritorno Inattivi"
 	GRM_L["resetall"] = "resetta tutto"
 	GRM_L["resetguild"] = "resetta gilda"
-	GRM_L["Notify When Players Request to Join the Guild"] = "Notifica quando dei giocatori chiedono di unirsi alla Gilda"
 	--Side chat/log controls - Of note, limited spacing
 	GRM_L["Name Change"] = "Cambio nome"
 	GRM_L["Rank Renamed"] = "Grado rinominato"
@@ -331,7 +318,6 @@ GRML.Italian = function()
 	GRM_L["Join Date"] = "Data di Entrata"
 	GRM_L["Promo Date"] = "Data Promozione"
 	GRM_L["Main/Alt"] = "Main/Alt"
-	GRM_L["Click Player to Edit"] = "Clicca un giocatore\nper modificare"
 	GRM_L["Only Show Incomplete Guildies"] = "Mostra solo gildani Incompleti"
 
 	-- ADDON SYSTEM MESSAGES
@@ -340,8 +326,6 @@ GRML.Italian = function()
 	GRM_L["(Ver:"] = "(Ver:"                                                               -- Ver: is short for Version:
 	GRM_L["GRM Updated:"] = "GRM Aggiornato:"
 	GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = "Configurazione di Guild Roster Manager per {name} per la prima volta"
-	GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = "Riattivazione scansione automatica dei cambiamenti"
-	GRM_L["Reactivating Data Sync..."] = "Riattivazione Sincronizzazione"
 	GRM_L["Notification Set:"] = "Notifica impostata:"
 	GRM_L["Report When {name} is ACTIVE Again!"] = "Riceverai una notifica quando {name} tornerà ATTIVO"
 	GRM_L["Report When {name} Comes Online!"] = "Riceverai una notifica quando {name} tornerà ONLINE"
@@ -351,10 +335,6 @@ GRML.Italian = function()
 	GRM_L["Player Does Not Have a Time Machine!"] = "I Giocatori non hanno una Macchina del Tempo!"
 	GRM_L["Please choose a valid DAY"] = "Per favore scegli un GIORNO valido"
 	GRM_L["{name} has been Removed from the Ban List."] = "{name} è stato rimosso dalla Lista Ban"
-	GRM_L["{num} Players Have Requested to Join the Guild."] = "{num} giocatori hanno rischiesto di unirsi alla Gilda"
-	GRM_L["A Player Has Requested to Join the Guild."] = "Un Giocatore ha chiesto di unirsi alla Gilda."
-	GRM_L["Click Link to Open Recruiting Window:"] = "Clicca per aprire la finestra di Reclutamento"
-	GRM_L["Guild Recruits"] = "Reclutamento di Gilda"
 	GRM_L["Scanning for Guild Changes Now. One Moment..."] = "Scansione dei cambiamenti in corso. Un momento..."
 	GRM_L["Breaking current Sync with {name}."] = "Interruzione della sincronizzazione con {name}."
 	GRM_L["Breaking current Sync with the Guild..."] = "Interruzione della sincronizzazione con la Gilda..."
@@ -362,8 +342,6 @@ GRML.Italian = function()
 	GRM_L["No Players Currently Online to Sync With..."] = "Non ci sono giocatori Online con cui sincronizzarsi"
 	GRM_L["No Addon Users Currently Compatible for FULL Sync."] = "Non ci sono utenti compatibili per una sincronizzazione completa"
 	GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = "Non è possibile sincronizzare! Impossibile sincronizzare quando la chat di gilda è limitata"
-	GRM_L["There are No Current Applicants Requesting to Join the Guild."] = "Attualmente non ci sono candidati."
-	GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = "La lista delle richieste non è visibile senza i permessi di invito."
 	GRM_L["Manual Scan Complete"] = "Scansione Manuale completata"
 	GRM_L["Analyzing guild for the first time..."] = "Prima scansione della gilda..."
 	GRM_L["Building Profiles on ALL \"{name}\" members"] = "Costruzione profili di tutti i membri di \"{name}\""                -- {name} will be the Guild Name, for context
@@ -372,11 +350,6 @@ GRML.Italian = function()
 	GRM_L["{name} is now OFFLINE!"] = "{name} è andato OFFLINE!"
 	GRM_L["{name} is No Longer AFK or Busy!"] = "{name} è tornato Disponibile!" 
 	GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = "{name} non è più AFK o Occupato, ma è andato OFFLINE!"
-	GRM_L["{name} is Already in Your Group!"] = "{name} è già nel tuo Gruppo!"
-	GRM_L["GROUP NOTIFICATION:"] = "NOTIFICA PER IL GRUPPO"
-	GRM_L["Players Offline:"] = "Giocatori Offline:"
-	GRM_L["Players AFK:"] = "Giocatori AFK:"
-	GRM_L["40 players have already been invited to this Raid!"] = "Sono già stati invitati 40 giocatori nel Gruppo Raid!"
 	GRM_L["Player should try to obtain group invite privileges."] = "Per favore, cerca di ottenere la possibilità di invitare in gruppo"
 	GRM_L["{name}'s saved data has been wiped!"] = "I dati di {name} sono stati cancellati!"
 	GRM_L["Re-Syncing {name}'s Guild Data..."] = "Risincronizzazione con i dati di {name}"
@@ -396,7 +369,6 @@ GRML.Italian = function()
 	GRM_L["Triggers manual re-sync if sync is enabled"] = "Effettua manualmente la sincronizzazione se è abilitata"
 	GRM_L["Does a one-time manual scan for changes"] = "Effettua una singola scansione dei cambiamenti "
 	GRM_L["Displays current Addon version"] = "Mostra la versione corrente dell'Add-on"
-	GRM_L["Opens Guild Recruitment Window"] = "Apri la finestra di Reclutamento di Gilda"
 	GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = "ATTENZIONE! Rimozione completa di tutti i dati, comprese le impostazioni, come se l'Add-On fosse stato appena installato";
 
 	-- General Misc UI
@@ -463,7 +435,6 @@ GRML.Italian = function()
 	GRM_L["sync"] = "sync"                            -- Context: "sync" the data between players one time now.
 	GRM_L["scan"] = "scan"                            -- Context: "scan" for guild roster changes one time now.
 	GRM_L["clearall"] = "clearall"                        -- Context: In regards, "Clear All" saved data
-	GRM_L["recruit"] = "reclute"                         -- Context: Open the roster "recruit" window where people request to join guild
 
 	-- CLASSES
 	GRM_L["Deathknight"] = "Cavaliere della Morte"
@@ -559,7 +530,6 @@ GRML.Italian = function()
 	GRM_L["Player is Not Currently in a Guild"] = "Il giocatore non è attualmente in una gilda"
 	-- tooltips
 	GRM_L["|CFFE6CC7FClick|r to open GRM"] = "|CFFE6CC7FClicca|r per aprire GRM"                         -- Please maintain the color coding
-	GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = "|CFFE6CC7FClick destro|r e trascina per muovere questo bottone."   -- Likewise, maintain color coding
 	GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = "|CFFE6CC7FClick destro|r per reimpostare al 100%"               -- for the Options slider tooltip
 	GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = "|CFFE6CC7FCLick destro|r per sincronizzare la data 	di entrata degli Alt"
 	GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = "|CFFE6CC7Click destro|r per impostare le notifiche del cambio di stato"
@@ -610,7 +580,6 @@ GRML.Italian = function()
 	GRM_L["{name} has been removed from the database."] = "{name} è stato rimosso dalla memoria"              -- The Guild Name has been removed from the database
 
 	-- update 1.141
-	GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = "Continuerai a condividere i tuoi dati con la gilda, ma stai accettando modifiche solo dal grado \"{name}\" o più alto"    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
 	GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = "Limita, in base al grado, solo i dati in ingresso, non in uscita"
 	GRM_L["Total Entries: {num}"] = "Voci totali: {num}"
 	GRM_L["Search Filter"] = "Cerca nel Registro"
@@ -642,9 +611,6 @@ GRML.Italian = function()
 
 	-- update 1.145
 	GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = "Attualmente hai {num} amici non Battle-tag. Per sfruttare appieno le funzioni di GRM considera di fare un po' di spazio."
-	GRM_L["Clear Space on Friends List to Find Online Status"] = "Fai spazio nella Lista Amici per vedere lo stato del giocatore" --WIP
-	GRM_L["Offline"] = "Offline"
-	GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = "{name} ha richiesto di unirsi alla gilda ed è attualmente ONLINE!"
 
 	-- Update 1.146
 	GRM_L["Really Clear line {num}?"] = "Vuoi davvero eliminare la riga {num}"
@@ -655,7 +621,6 @@ GRML.Italian = function()
 	GRM_L["Right-Click to Reset to 100%"] = "Click destro per reimpostare al 100%"
 
 	-- Update 1.147
-	GRM_L["|CFFE6CC7FClick|r to open Player Window"] = "|CFFE6CC7FClicca|r per aprire la finestra del giocatore"
 	GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = "|CFFE6CC7FCtrl-Shift-Click|r per cercare il player nel Registro"
 
 	-- Update 1.1480
@@ -669,20 +634,15 @@ GRML.Italian = function()
 	GRM_L["Sync Custom Notes"] = "Sincronizza le Note Personalizzate"
 	GRM_L["Default Custom Note Rank Minimum"] = "Grado minimo Predefinito per sincronizzare"
 	GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = "Reimposta le restrizioni Predefinite per TUTTI i gildani"
-	GRM_L["Reset to Default"] = "Reimposta a Predefinito"
 	GRM_L["Reset"] = "Reimposta"
 	GRM_L["|CFF00CCFFDefault Selection For All Players"] = "|CFF00CCFFImpostazione predefinita per tutti i giocatori"
-	GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = "Se la Sincronizzazione con alcuni gildani è stata limitata manualmente, questo NON la riabilita"
-	GRM_L["Custom note Sync has been reset to default"] = "Le impostazioni di Sincronizzazione delle Note Personalizzate sono state resettate"
 	GRM_L["Click here to set Custom Notes"] = "Clicca per impostare una Nota Personalizzata"
 	GRM_L["|CFF00CCFFCustom Note Defaults:"] = "|CFF00CCFFNota Personalizzata predefinita:"
 	GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = "|CFFE6CC7FClick Sinistro|r per riabilitare la sincronizzazione\ndelle Note Personalizzate per tutti"
-	GRM_L["Custom Note Sync Disabled in Settings"] = "La Sincronizzazione delle Note Personalizzate è disabilitata"
 	GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = "{name} ha modificato la Nota Personalizzata di {name2}: \"{custom1}\" è stato aggiunto"
 	GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = "{name} ha modificato la Nota Personalizzata di {name2}: \"{custom1}\" è stato rimosso"
 	GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = "{name} ha modificato la Nota Personalizzata di {name2} da \"{custom1}\" a \"{custom2}\""
 	GRM_L["Custom Note"] = "Nota Personalizzata"
-	GRM_L["Syncing Outgoing Data."] = "Sincronizzazione dei Dati in Uscita"
 	GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = "|CFFE6CC7FClicca|r per cambiare le restrizioni sul Grado"
 	GRM_L["|CFFE6CC7FClick|r to Change Day"] = "|CFFE6CC7FClicca|r per cambiare il Giorno"
 	GRM_L["|CFFE6CC7FClick|r to Change Month"] = "|CFFE6CC7FClicca|r per cambiare il Mese";
@@ -702,10 +662,6 @@ GRML.Italian = function()
 	GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = "|CFFE6CC7FClicca|r per cambiare la Lingua"
 	GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = "|CFFE6CC7FClicca|r per cambiare il Formato"
 	GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = "|CFFE6CC7FClicca|r per cambiare il Carattere"
-	GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = "Sfortunatamente la data di ogni giocatore andrà riconfigurata manualmente"
-	GRM_L["{num} custom {custom1} removed that matched text:"] = "{num} {custom1} personalizzata che corrispondeva al testo è stata rimossa:" --Can I have two of this? One for the plural?  WIP                    -- custom1 = "note" or the plural "notes"
-	GRM_L["notes"] = "note"
-	GRM_L["Please add specific text, in quotations, to match"] = "Per favore, aggiungi tra virgolette il testo specifico da trovare"
 
 	-- R1.1490
 	GRM_L["You will still share some outgoing data with the guild"] = "Condividerai comunque alcuni dati con la gilda"
@@ -717,8 +673,6 @@ GRML.Italian = function()
 	GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = "utilizzala solo come stima. Si spera che la Blizzard risolva presto"
 	GRM_L["{name}'s Anniversary!"] = "Anniversario di {name}!"
 	GRM_L["{name}'s Birthday!"] = "Compleanno di {name}!"
-	GRM_L["Guild member for over {num} year"] = "Membro di Gilda da più di un anno"
-	GRM_L["Guild member for over {num} years"] = "Membro di Gilda da più di {num} anni"   -- the plural version!
 	GRM_L["Add Upcoming Events to the Calendar"] = "Aggiungi gli eventi imminenti al Calendario"
 	GRM_L["Player rank unable to add events to calendar"] = "I giocatori con questo grado non possono aggiungere eventi al calendario"
 	GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = "Anniversari, Compleanni, ed altri eventi possono essere aggiunti con il permesso" --WIP
@@ -727,7 +681,6 @@ GRML.Italian = function()
 	GRM_L["Check the \"Sync Users\" tab to find out why!"] = "Controlla la scheda \"Sincronizza\" per capire perché!"
 	GRM_L["Time as Member:"] = "Membro da:"
 	GRM_L["|CFFE6CC7FClick|r to select player event"] = "|CFFE6CC7FClicca|r per selezionare un evento"
-	GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = "|CFFE6CC7FClicca di nuovo|r per aprire la finestra del Giocatore"
 	GRM_L["Timestamp Format:"] = "Formato Data e Ora"
 	GRM_L["Hour Format:"] = "Formato Orario"
 	GRM_L["24 Hour"] = "24 Ore"
@@ -761,31 +714,16 @@ GRML.Italian = function()
 	GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = "|CFFE6CC7FClicca|r per ordinare le date di promozione dalla più vecchia"
 	GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = "|CFFE6CC7FClicca|r per ordinare mettendo prima tutti i Main"
 	GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = "|CFFE6CC7FClicca|r per ordinare mettendo prima tutti gli Alt."
-	GRM_L["{name}'s Profile is Being Built. One Moment..."] = "Profilo di {name} in costruzione. Un momento..."
-	GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = "Ci sono {num} giocatore che chiedono di unirsi alla gilda. Hai spazio sono per altri {custom1} amici. Per favore prendi in considerazione di pulire la lista amici e la lista del reclutamento.";
 	GRM_L["{name}'s Alts"] = "Alt di {Name}"                                   -- Like "Arkaan's Alts"
-	GRM_L["Online:  {num}/{custom1}"] = "Online:  {num}/{custom1}"                         -- As in "Online: 3/59"
-	GRM_L["Next"] = "Prossimo"                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-	GRM_L["Previous"] = "Precedente"                                       -- Same context as the "next" except this one goes back to the one before.
-	GRM_L["There are currently no ONLINE recruits."] = "Attualmente non ci sono candidati ONLINE"
-	GRM_L["There are currently no more players in that direction."] = "Non ci sono altri giocatori in quella direzione"
-	GRM_L["You have reached the end of the list"] = "Hai raggiunto la fine della lista"
-	GRM_L["You have reached the top of the list"] = "Hai raggiunto l'inizio della lista"
-	GRM_L["Auto Open Window"] = "Apri automaticamente\nla finestra"
-	GRM_L["Only if a player is online and you are not in combat"] = "Solo se un giocatore è online e non sei in combattimento" --Combat o combattimento?
-	GRM_L["Recruit window will open when combat ends."] = "La finestra di reclutamento si aprirà alla fine del combattimento"
 	GRM_L["GRM window will open when combat ends."] = "La finestra di GRM si aprirà alla fine del combattimento"
 	
 	-- R1.24
 	GRM_L["This also will change the <Alt> format to match"] = "Anche il formato degli <Alt> verrà cambiato"
 	GRM_L["M"] = "M"                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
 	GRM_L["A"] = "A"          
-	GRM_L["<M>"] = "<M>"                                         -- <M> appears for "Main"
-	GRM_L["<A>"] = "<A>"                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
 	-- R1.25
 	GRM_L["Include \"Joined:\" tag with the date."] = "Utilizza la tag \"Entrato il:\" assieme alla data"                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-	GRM_L["Joined: {name}"] = "Entrato il: {name}"                                                                -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
 	GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = "GRM Auto-Detect! {name} è entrato in gilda ed è stato impostato come Main"            -- Main auto-detect message
 
 	-- R1.26
@@ -804,26 +742,15 @@ GRML.Italian = function()
 	GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
 	GRM_L["Hard Reset"] = "Reset Totale"
 	GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = "Reset TOTALE dei dati di GRM, per tutto l'account.\n Il gioco verrà ricaricato!"
-	GRM_L["Reject\nAll"] = "Rifiuta\nTutti"                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-	GRM_L["{num} Applicants to the Guild have been denied"] = "{num} candidati alla gilda sono stati rifiutati"
-	GRM_L["Do you really want to reject all applicants?"] = "Vuoi davvero rifiutare tutte le richieste?"
 	GRM_L["Only recommend to kick if all player linked alts exceed max time"] = "Raccomanda di rimuovere solo se tutti gli alt del giocatore superano il tempo massimo"
 	GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = "Il Capo Gilda ha impostato le restrizioni per la sincronizzazione a {name} o più"
 	GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = "Impossibile cambiare il Grado. Il Capo Gilda ha impostato le restrizioni a {name} o più"    -- Like Initiate or higher
 	GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = "Impossibile cambiare il Grado. Il Capo Gilda ha impostato delle restrizioni"
-	GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = "Unifica le impostazioni per tutti i gildani con i comandi \"g#^X\""
-	GRM_L["CONTROL TAGS:"] = "TAG DI CONTROLLO"
 	GRM_L["Force Settings with Guild Info Tags"] = "Tag per forzare le impostazioni dalle info di Gilda"
 	GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = "Attenzione! I messaggi di Sistema sono disabilitati! GRM non può funzionare bene senza, riabilitali nelle impostazioni della chat."
 	GRM_L["Database Still Loading. GRM will open automatically when finished."] = "Il database si sta caricando. GRM si aprirà automaticamente quando il caricamento è finito."
 
 	-- R1.29
-	GRM_L["Do you really want to invite all applicants?"] = "Vuoi davvero invitare tutti i candidati?"
-	GRM_L["There are currently 0 players online to invite."] = "Non ci sono giocatori online da invitare"
-	GRM_L["It appears all players are now offline."] = "Sembra che tutti i giocatori siano offline"
-	GRM_L["Invite\nAll"] = "Invita\nTutti"                            -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-	GRM_L["Include Message When Sending Invite"] = "Includi un messaggio quando mandi l'invito"
-	GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = "Clicca qui per impostare un messaggio di invito personalizzato. Premi Invio prima di mandare un invito!"
 	GRM_L["The highlighted character is not valid for messages. Please remove."] = "Il carattere evidenziato non è utilizzabile nei messaggi. Per favore rimuovilo."
 	GRM_L["Not all characters are valid. Please remove any non-text characters."] = "Ci sono dei caratteri che non sono validi. Per favore rimuovi tutti i caratteri non di testo" --WIP
 	GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = "Macro per rimuovere creata. Premi \"CTRL-SHIFT-K\" per cacciare tutti gli alt di {name}"
@@ -835,7 +762,6 @@ GRML.Italian = function()
 
 	-- R1.30
 	GRM_L["Sync With {name} is Complete..."] = "La sincronizzazione con {name} è completa..."
-	GRM_L["Database Still Loading. Please Wait..."] = "Il database si sta caricando. Attendere prego..."
 	GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = "|CFFE6CC7FLeft-Clicca|r e trascina per spostare questo tasto."
 	GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = "|CFFE6CC7FLeft-Clicca|r e trascina per spostare questo tasto ovunque."
 	GRM_L["MOTD:"] = "MDG:"       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +771,12 @@ GRML.Italian = function()
 	GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = "Mostra la tag \"Main\" in chat sia per i Main che per gli Alt"
 
 	-- R1.32
-	GRM_L["Invites Currently Being Sent..."] = "Spedizione degli inviti in corso..."
 	GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = "GRM ha spostato le impostazioni delle restrizioni per i Capo Gilda nella finestra delle informazioni della Gilda"
 	GRM_L["Please make room for them and re-add."] = "Per favore, fai spazio e poi invita di nuovo"
-	GRM_L["Your Guild Leader has pushed a reset of your data."] = "I tuoi dati sono stati resettati dal Capo Gilda";
 	GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = "Il Capo Gilda ha impostato la restrizione della sincronizzazione dei BAN a {name} o più"
 	GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = "Il Capo Gilda ha impostato la restrizione della sincronizzazione delle NOTE PERSONALIZZATE a {name} o più"
 
 	-- R1.33
-	GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = "Macro per invitare tutti creata. Premi \"CTRL-SHIFT-K\" per invitare tutte le reclute online."
 	GRM_L["Macro will auto-remove after {num} seconds."] = "La macro si cancellerà in {num} secondi."
 	GRM_L["UI"] = "UI"
 	GRM_L["UI Controls"] = "Impostazioni UI"
@@ -919,12 +842,10 @@ GRML.Italian = function()
 	-- R1.41  
 	GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = "Creazione di {num} profili metadati per gli ex-gildani in corso. Sto richiedendo i dati, ma ci potrebbe volere un po' di tempo."    --WIP               -- PLURAL
 	GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = "Creazione del profilo metadati per l'ex-gildano in corso. Sto richiedendo i dati, ma ci potrebbe volere un po' di tempo."    --WIP       -- SINGULAR, same line.
-	GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = "La sincronizzazione si riattiverà a breve, per raccogliere i dati definitivi sui profili."
 	GRM_L["Auto-Focus the search box"] = "Auto-focus della casella di ricerca"
 	GRM_L["This will skip the first time if set to load on logon"] = "Non funzionerà all'avvio, se l'impostazione \"Mostra all'avvio\" è attivata"  -- Referring to the auto-focusing on the search box, this is a tooltip helper
 	GRM_L["Please enter a valid level between 1 and {num}"] = "Per favore, inserisci un livello tra 1 e {num}"
 	GRM_L["Player's Main: {name}"] = "Main: {name}"
-	GRM_L["Player's main no longer in the guild: {name}"] = "Il main di {name} non è più in gilda"
 
 	-- R1.43
 	GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = "Un momento, sto richiedendo altri dettagli su {name} al server. La lista dei Ban verrà aggiornata a breve."
@@ -960,7 +881,6 @@ GRML.Italian = function()
 		
 		-- 1.56
 	-- More slash commands
-	GRM_L["recruits"] = "recluta" 
 	GRM_L["kick"] = "rimuovi"
 	GRM_L["ban"] = "ban"
 	GRM_L["audit"] = "verifica"
@@ -998,7 +918,6 @@ GRML.Italian = function()
 	GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = "|CFFE6CC7FShift-Click|r un secondo giocatore per selezionare anche quelli in mezzo"
 	GRM_L["|CFFE6CC7FClick|r to select player"] = "|CFFE6CC7FClicca|r per selezionare un giocatore"
 	GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = "|CFFE6CC7FCtrl-Click|r per aprire la finestra del giocatore"
-	GRM_L["Please manually select your guild in the Community Window for this feature to work"] = "Seleziona manualmente la gilda nella Finestra delle Comunità per abilitare questa funzione"
 	GRM_L["Only Show Players With Incomplete Status"] = "Mostra solo i giocatori con status incompleto"
 	GRM_L["{num} Join Dates Need Attention"] = "{num} date di entrata necessitano attenzione "             -- In other words, "155 join dates need attention" as an example
 	GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = "Vuoi davvero rimuovere le date di entrata da tutte le note tranne le {name}?"
@@ -1038,16 +957,12 @@ GRML.Italian = function()
 
 	-- 1.57
 	GRM_L["Full Log Message:"] = "Messaggio completo:"
-	GRM_L["Public Notes"] = "Note Pubbliche"
-	GRM_L["Officer Notes"] = "Note Ufficiali"
-	GRM_L["Custom Notes"] = "Note Personalizzate"
 	GRM_L["Log Entry Tooltip"] = "Tooltip voci registro"
 	GRM_L["1 entry has been removed from the log"] = "1 voce è stata rimossa dal registro"
 	GRM_L["{num} entries have been removed from the log"] = "{num} voci sono state rimosse dal registro"
 
 	-- 1.58
 	GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = "|CFFE6CC7FCtrl-Clicca|r per utilizzare la vecchia versione dell'elenco di gilda"
-	GRM_L["Using the Old Guild Roster Interface instead"] = "Utilizza la vecchia versione dell'elenco di gilda"
 
 	-- 1.59
 	GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = "È impossibile disabilitare l'inserimento della data di entrata a causa delle impostazioni globali"
@@ -1100,8 +1015,6 @@ GRML.Italian = function()
 	GRM_L["No Current Names to Add"] = true
 	GRM_L["No Names to Add to the Macro"] = true
 	GRM_L["Hot Key: {name}"] = true
-	GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-	GRM_L["Press the Hot-key {num} times to complete all actions"] = true
 	GRM_L["Permissions"] = true
 	GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
 	GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1164,7 +1077,6 @@ GRML.Italian = function()
 	-- CLASSIC
 	GRM_L["Social"] = true
 	GRM_L["Roster"] = true
-	GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
 	GRM_L["Feature is disabled in WoW Classic"] = true
 	GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
 	GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1119,7 @@ GRML.Italian = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1150,6 @@ GRML.Italian = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1312,7 +1221,6 @@ GRML.Italian = function()
 
 	-- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1335,7 +1243,6 @@ GRML.Italian = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1366,7 +1273,6 @@ GRML.Italian = function()
 	
 	-- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1392,7 +1298,6 @@ GRML.Italian = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-	GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
 	GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
 	
@@ -1420,7 +1325,6 @@ GRML.Italian = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1481,7 +1385,6 @@ GRML.Italian = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/Korean.lua
+++ b/locales/Korean.lua
@@ -79,7 +79,6 @@ GRML.Korean = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.Korean = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.Korean = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.Korean = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.Korean = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.Korean = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.Korean = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.Korean = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.Korean = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.Korean = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.Korean = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.Korean = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.Korean = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "죽음의 기사"
@@ -560,7 +531,6 @@ GRML.Korean = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.Korean = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.Korean = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.Korean = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.Korean = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.Korean = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -718,8 +674,6 @@ GRML.Korean = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -728,7 +682,6 @@ GRML.Korean = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -762,31 +715,16 @@ GRML.Korean = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -805,26 +743,15 @@ GRML.Korean = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -835,7 +762,6 @@ GRML.Korean = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +771,12 @@ GRML.Korean = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -919,12 +842,10 @@ GRML.Korean = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -960,7 +881,6 @@ GRML.Korean = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -998,7 +918,6 @@ GRML.Korean = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1038,16 +957,12 @@ GRML.Korean = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1100,8 +1015,6 @@ GRML.Korean = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1164,7 +1077,6 @@ GRML.Korean = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1119,7 @@ GRML.Korean = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1150,6 @@ GRML.Korean = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1311,7 +1220,6 @@ GRML.Korean = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1242,6 @@ GRML.Korean = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1272,6 @@ GRML.Korean = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1297,6 @@ GRML.Korean = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1324,6 @@ GRML.Korean = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1480,7 +1384,6 @@ GRML.Korean = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/MandarinCN.lua
+++ b/locales/MandarinCN.lua
@@ -79,7 +79,6 @@ GRML.MandarinCN = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.MandarinCN = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.MandarinCN = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.MandarinCN = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.MandarinCN = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.MandarinCN = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.MandarinCN = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.MandarinCN = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.MandarinCN = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.MandarinCN = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.MandarinCN = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.MandarinCN = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.MandarinCN = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "死亡骑士"
@@ -560,7 +531,6 @@ GRML.MandarinCN = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.MandarinCN = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.MandarinCN = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.MandarinCN = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.MandarinCN = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.MandarinCN = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -718,8 +674,6 @@ GRML.MandarinCN = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -728,7 +682,6 @@ GRML.MandarinCN = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -762,31 +715,16 @@ GRML.MandarinCN = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -805,26 +743,15 @@ GRML.MandarinCN = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -835,7 +762,6 @@ GRML.MandarinCN = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +771,12 @@ GRML.MandarinCN = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -919,12 +842,10 @@ GRML.MandarinCN = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -960,7 +881,6 @@ GRML.MandarinCN = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -998,7 +918,6 @@ GRML.MandarinCN = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1038,16 +957,12 @@ GRML.MandarinCN = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1100,8 +1015,6 @@ GRML.MandarinCN = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1164,7 +1077,6 @@ GRML.MandarinCN = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1119,7 @@ GRML.MandarinCN = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1150,6 @@ GRML.MandarinCN = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1311,7 +1220,6 @@ GRML.MandarinCN = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1242,6 @@ GRML.MandarinCN = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1272,6 @@ GRML.MandarinCN = function()
     
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1297,6 @@ GRML.MandarinCN = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1324,6 @@ GRML.MandarinCN = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1480,7 +1384,6 @@ GRML.MandarinCN = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/MandarinTW.lua
+++ b/locales/MandarinTW.lua
@@ -79,7 +79,6 @@ GRML.MandarinTW = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.MandarinTW = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.MandarinTW = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.MandarinTW = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.MandarinTW = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.MandarinTW = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.MandarinTW = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.MandarinTW = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.MandarinTW = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.MandarinTW = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.MandarinTW = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.MandarinTW = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.MandarinTW = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "死亡騎士"
@@ -560,7 +531,6 @@ GRML.MandarinTW = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.MandarinTW = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.MandarinTW = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.MandarinTW = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.MandarinTW = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.MandarinTW = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -718,8 +674,6 @@ GRML.MandarinTW = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -728,7 +682,6 @@ GRML.MandarinTW = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -762,31 +715,16 @@ GRML.MandarinTW = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
     
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -805,26 +743,15 @@ GRML.MandarinTW = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -835,7 +762,6 @@ GRML.MandarinTW = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +771,12 @@ GRML.MandarinTW = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -919,12 +842,10 @@ GRML.MandarinTW = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -960,7 +881,6 @@ GRML.MandarinTW = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -998,7 +918,6 @@ GRML.MandarinTW = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1038,16 +957,12 @@ GRML.MandarinTW = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
 
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
 
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1100,8 +1015,6 @@ GRML.MandarinTW = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1164,7 +1077,6 @@ GRML.MandarinTW = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1119,7 @@ GRML.MandarinTW = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1150,6 @@ GRML.MandarinTW = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1311,7 +1220,6 @@ GRML.MandarinTW = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1242,6 @@ GRML.MandarinTW = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1272,6 @@ GRML.MandarinTW = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1297,6 @@ GRML.MandarinTW = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1324,6 @@ GRML.MandarinTW = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1480,7 +1384,6 @@ GRML.MandarinTW = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/Portuguese.lua
+++ b/locales/Portuguese.lua
@@ -79,7 +79,6 @@ GRML.Portuguese = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.Portuguese = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.Portuguese = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.Portuguese = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.Portuguese = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.Portuguese = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.Portuguese = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.Portuguese = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.Portuguese = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.Portuguese = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.Portuguese = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.Portuguese = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.Portuguese = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "Cavaleiro da Morte"
@@ -560,7 +531,6 @@ GRML.Portuguese = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.Portuguese = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.Portuguese = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.Portuguese = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.Portuguese = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.Portuguese = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -718,8 +674,6 @@ GRML.Portuguese = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -728,7 +682,6 @@ GRML.Portuguese = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -762,31 +715,16 @@ GRML.Portuguese = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -805,26 +743,15 @@ GRML.Portuguese = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -835,7 +762,6 @@ GRML.Portuguese = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +771,12 @@ GRML.Portuguese = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -919,12 +842,10 @@ GRML.Portuguese = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -960,7 +881,6 @@ GRML.Portuguese = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -998,7 +918,6 @@ GRML.Portuguese = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1038,16 +957,12 @@ GRML.Portuguese = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
     
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1100,8 +1015,6 @@ GRML.Portuguese = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1164,7 +1077,6 @@ GRML.Portuguese = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1207,9 +1119,7 @@ GRML.Portuguese = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1150,6 @@ GRML.Portuguese = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1311,7 +1220,6 @@ GRML.Portuguese = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1242,6 @@ GRML.Portuguese = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1272,6 @@ GRML.Portuguese = function()
 
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1297,6 @@ GRML.Portuguese = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1324,6 @@ GRML.Portuguese = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1480,7 +1384,6 @@ GRML.Portuguese = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/PortugueseBR.lua
+++ b/locales/PortugueseBR.lua
@@ -79,7 +79,6 @@ GRML.PortugueseBR = function()
     GRM_L["Edit Promo Date"] = "Editar Data de Promoção"
     GRM_L["Edit Join Date"] = "Editar Data de Entrada"
     GRM_L["Set Promo Date"] = "Setar Data de Promoção"
-    GRM_L["In Group"] = "Em Grupo"                           -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = "Invite de Grupo"
     GRM_L["No Invite"] = "Sem Invite"
     GRM_L["Group Invite"] = "Invite de Grupo"
@@ -93,7 +92,6 @@ GRML.PortugueseBR = function()
     GRM_L["Player Alts"] = "Alts do Jogador"
     GRM_L["Add Alt"] = "Adc Alt"
     GRM_L["Choose Alt"] = "Escolher Alt"
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = "Shift-Mouseover no Nome da Lista Também Funciona"
     GRM_L["Guild Log"] = "Registro"
     GRM_L["Guild"] = "Guilda"
 
@@ -122,12 +120,9 @@ GRML.PortugueseBR = function()
     GRM_L["Guild Roster Event Log"] = "Registro de Eventos"
     GRM_L["Clear Log"] = "Limpar Registro"
     GRM_L["Really Clear the Guild Log?"] = "Quer mesmo Limpar o Registro da Guilda?"
-    GRM_L["{name} DEMOTED {name2}"] = "{name} REBAIXOU {name2}"
-    GRM_L["{name} PROMOTED {name2}"] = "{name} PROMOVEU {name2}"
     GRM_L["{name} KICKED {name2} from the Guild!"] = "{name} EXPULSOU {name2} da Guilda!"
     GRM_L["kicked"] = "expulso"
     GRM_L["{name} has Left the guild"] = "{name} Saiu da guilda"
-    GRM_L["{name} INVITED {name2} to the guild."] = "{name} CONVIDOU {name2} para a guilda."
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = "{name} BANIU {name2} e todos os alts interligados da guilda!"
     GRM_L["{name} has BANNED {name2} from the guild!"] = "{name} BANIU {name2} da guilda!" 
     GRM_L["Reason Banned:"] = "Razão do Banimento:"
@@ -157,7 +152,6 @@ GRML.PortugueseBR = function()
     GRM_L["{name} has JOINED the guild!"] = "{name} ENTROU na guilda!"
     GRM_L["Date Left:"] = "Data de Saída:"
     GRM_L["{name} has Leveled to {num}"] = "{name} subiu de Nível para {num}"
-    GRM_L["Leveled to"] = "Subiu de Nível para"                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = "(+{num} níveis)"                                        -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = "(+{num} nível)"                                         -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = "Nota PÚBLICA de {name}: \"{custom1}\" foi Adicionada"           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.PortugueseBR = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = "Cargo de Guilda Renomeado de {custom1} para {custom2}"
     GRM_L["{name} has Name-Changed to {name2}"] = "{name} Mudou de Nome para {name2}"
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = "{name} está ONLINE depois de ficar INATIVO por {num}"
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = "{name } Parece ter Mudado de Nome, mas o seu Novo Nome foi Difícil de Determinar"
-    GRM_L["It Could Be One of the Following:"] = "Pode Ser Um dos Seguintes:"
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = "{name} esteve OFFLINE por {num}. Expulsão Recomendada!"
     GRM_L["({num} ago)"] = "({num} atrás)"                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = "A Guilda de {name} Mudou de Nome para \"{name2}\""
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = "{name} estará celebrando {num} ano na Guilda! ( {custom1} )"           -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = "{name} estará celebrando {num} anos na Guilda! ( {custom1} )"           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = "Promoções"
     GRM_L["Demotions"] = "Rebaixamentos"
 
@@ -196,7 +186,6 @@ GRML.PortugueseBR = function()
     GRM_L["No Calendar Events to Add"] = "Nenhum Evento de Calendário para Adicionar"
     GRM_L["{name}'s event has already been added to the calendar!"] = "o evento de {name} já foi adicionado ao calendário!"
     GRM_L["Please wait {num} more seconds to Add Event to the Calendar!"] = "Por Favor espere mais {num} segundos para Adicionar Evento ao Calendário!"
-    GRM_L["{name}'s Event Removed From the Queue!"] = "Evento de {name} foi Removido da Fila!"
     GRM_L["Full Description:"] = "Descrição Total:"
 
     -- BAN WINDOW DONE
@@ -231,7 +220,6 @@ GRML.PortugueseBR = function()
     GRM_L["No Reason Given"] = "Não Informado"
 
     -- ADDON USERS WINDOW DONE
-    GRM_L["SYNC USUÁRIOS"] = "SINC USUÁRIOS"
     GRM_L["Ok!"] = true
     GRM_L["Their Rank too Low"] = "Cargos Deles é Muito Baixo"
     GRM_L["Your Rank too Low"] = "Seu Cargo é Muito Baixo"
@@ -291,13 +279,10 @@ GRML.PortugueseBR = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = "Desativando SINCRONIA de Dados com Membros..."
     GRM_L["Display Sync Update Messages"] = "Exibir Mensagens de Atualização de Sincronização"
     GRM_L["Only Sync With Up-to-Date Addon Users"] = "Sincronizar Apenas com Usuários do Addon Mais Atual"
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = "Somente Anunciar Aniversários se Listado como 'Main'"
     GRM_L["Leveled"] = "Subiu de Nível"
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = "Retorno Inativo"
     GRM_L["resetall"] = "resetetudo"
     GRM_L["resetguild"] = "reseteguilda"
-    GRM_L["Notify When Players Request to Join the Guild"] = "Notificar Quando Jogadores Solicitarem Entrar na Guilda"
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = "Mudança de Nome"
     GRM_L["Rank Renamed"] = "Cargo Renomeado"
@@ -330,7 +315,6 @@ GRML.PortugueseBR = function()
     GRM_L["Join Date"] = "Entrada"
     GRM_L["Promo Date"] = "Promovido"
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = "Clique um Jogador para Editar"
     GRM_L["Only Show Incomplete Guildies"] = "Apenas Exibir Membros Incompletos"
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +323,6 @@ GRML.PortugueseBR = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +332,6 @@ GRML.PortugueseBR = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +339,6 @@ GRML.PortugueseBR = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +347,6 @@ GRML.PortugueseBR = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +366,6 @@ GRML.PortugueseBR = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = "Desencadeia re-sincronia manual se a sincronia estiver habilitada"
     GRM_L["Does a one-time manual scan for changes"] = "Faz uma varredura manual única em busca de alterações"
     GRM_L["Displays current Addon version"] = "Exibe versão atual do Addon"
-    GRM_L["Opens Guild Recruitment Window"] = "Abre Janela de Recrutes da Guilda"
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = "AVISO! limpeza completa, incluindo configurações, como se o addon tivesse acabado de ser instalado."
 
     -- General Misc UI Done
@@ -464,7 +434,6 @@ GRML.PortugueseBR = function()
     GRM_L["sync"] = "sincronizar"                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = "limpardados"                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = "recrutar"                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "Cavaleiro da Morte"
@@ -536,11 +505,6 @@ GRML.PortugueseBR = function()
     GRM_L["< 1 day"] = "< 1 dia"
 
     GRM_L["{num} an"] = true
-    GRM_L["{num} ans"] = true
-    GRM_L["{num} m"] = true
-    GRM_L["{num} ms"] = true
-    GRM_L["{num} h"] = true
-    GRM_L["{num} hs"] = true
     GRM_L["< 1 hour"] = "< 1 hora"
     GRM_L["{num} {custom1}"] = true     -- Context: This is a placeholder for ANY generic time data -- Ex:  "1 year" or "15 months" - The translation is set this is just to set the orientation of the number properly.
 
@@ -560,7 +524,6 @@ GRML.PortugueseBR = function()
     GRM_L["Player is Not Currently in a Guild"] = "O Jogador Não está Atualmente em uma Guilda"
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = "|CFFE6CC7FClique|r para abrir o GRM"                          -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = "|CFFE6CC7FRight-Clique|r e arraste para mover esse botão."   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = "|CFFE6CC7FClique com o Direito|r para Resetar para 100%"                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = "|CFFE6CC7FClique com o Direito|r para Sincronizar Data de Entrada com os Alts"
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = "|CFFE6CC7FClique com o Direito|r para Setar Notificações de Mudança de Status"
@@ -611,7 +574,6 @@ GRML.PortugueseBR = function()
     GRM_L["{name} has been removed from the database."] = "{name} foi removido do banco de dados."              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = "Você ainda compartilhará seus dados com a guilda, mas atualmente está aceitando apenas alterações vindas do rank \" {name} \" ou superior"    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = "Total de Entradas: {num}"
     GRM_L["Search Filter"] = "Filtro de Pesquisa"
@@ -643,9 +605,6 @@ GRML.PortugueseBR = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = "Você tem atualmente {num} amigos sem Battletag. Para se aproveitar totalmente de todas as funcionalidades do GRM, por favor considere abrir espaço."
-    GRM_L["Clear Space on Friends List to Find Online Status"] = "Limpar Espaço na Lista de Amigos para Achar Status Online"
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = "{name} requisitou entrada na guilda e está ONLINE!"
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = "Realmente Limpar linha {num}?"
@@ -656,7 +615,6 @@ GRML.PortugueseBR = function()
     GRM_L["Right-Click to Reset to 100%"] = "Clique com o Direito para Resetar para 100%"
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = "|CFFE6CC7FClique|r para abrir a Janela do Jogador"
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = "|CFFE6CC7FCtrl-Shift-Click|r para Procurar Registro pelo Jogador"
 
     -- Update 1.1480
@@ -670,20 +628,15 @@ GRML.PortugueseBR = function()
     GRM_L["Sync Custom Notes"] = "Notas Customizadas de Sincronia"
     GRM_L["Default Custom Note Rank Minimum"] = "Cargo Padrão Mínimo para Notas Customizadas"
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = "Resetar Restrição de Nota Customizada para TODOS (Membros)"
-    GRM_L["Reset to Default"] = "Resetar para Padrão"
     GRM_L["Reset"] = "Resetar"
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = "|CFF00CCFFSeleção Padrão para Todos os Jogadores"
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = "Se a sincronia foi manualmente desabilitada por membros específicos, isso NÃO vai habilitá-la."
-    GRM_L["Custom note Sync has been reset to default"] = "Sincronia de nota Customizada foi resetada para padrão"
     GRM_L["Click here to set Custom Notes"] = "Clique aqui para setar Notas Customizadas"
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = "|CFF00CCFFPadrões de Notas Customizáveis:"
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = "|CFFE6CC7FLeft-Clique|r para re-habilitar sincronia de notas customizáveis para todos"
-    GRM_L["Custom Note Sync Disabled in Settings"] = "Sincronia de Notas Customizáveis Desativada nas Configurações"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = "{name} modificou a nota CUSTOMIZADA DE {name2}: \"{custom1}\" foi Adicionada"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = "{name} modificou a nota CUSTOMIZADA DE {name2}: \"{custom1}\" foi Removida"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = "{name} modificou a nota CUSTOMIZADA DE {name2}: \"{custom1}\" para \"{custom2}\""
     GRM_L["Custom Note"] = "Nota Customizada"
-    GRM_L["Syncing Outgoing Data."] = "Sincronizando Dados de Saída."
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = "|CFFE6CC7FClique|r para Mudar a Restrição de Rank"
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = "|CFFE6CC7FClique|r para Mudar o Dia"
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = "|CFFE6CC7FClique|r para Mudar o Mês"
@@ -703,10 +656,6 @@ GRML.PortugueseBR = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = "|CFFE6CC7FClique com O Esquerdo|r para Mudar o Idioma"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = "|CFFE6CC7FClique com O Esquerdo|r para Mudar o Formato de Exibição"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = "|CFFE6CC7FClique com O Esquerdo|r para Mudar a Fonte"
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = "Infelizmente todos os dados de cada jogador terão de ser reconfigurados manualmente."
-    GRM_L["{num} custom {custom1} removed that matched text:"] = "{num} {custom1} customizada/s removida/s com texto correspondente:"                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = "notas"
-    GRM_L["Please add specific text, in quotations, to match"] = "Por Favor Adicione texto específico, entre aspas, para corresponder"
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = "Você ainda compartilhará alguns dados enviados com a guilda"
@@ -718,8 +667,6 @@ GRML.PortugueseBR = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = "Use apenas como uma estimativa. Espero que a Blizz conserte isso em breve"
     GRM_L["{name}'s Anniversary!"] = "Aniversário de/a {name}!"
     GRM_L["{name}'s Birthday!"] = "Aniversário de/a {name}!"
-    GRM_L["Guild member for over {num} year"] = "Membro da Guilda por mais de {num} ano"
-    GRM_L["Guild member for over {num} years"] = "Membro da Guilda por mais de {num} anos"   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = "Adicionar Próximos Eventos ao Calendário"
     GRM_L["Player rank unable to add events to calendar"] = "Cargo de Jogador incapaz de adicionar eventos ao calendário"
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = "Aniversários e Outros Eventos podem ser adicionados com permissão"
@@ -728,7 +675,6 @@ GRML.PortugueseBR = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = "Cheque a aba \"Sinc Usuários\" para saber o porque!"
     GRM_L["Time as Member:"] = "Tempo como Membro:"
     GRM_L["|CFFE6CC7FClick|r to select player event"] = "| CFFE6CC7FClique|r para selecionar o evento do jogador"
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = "|CFFE6CC7FClique de Novo|r para abrir a Janela do Jogador"
     GRM_L["Timestamp Format:"] = "Formato Data/Hora:"
     GRM_L["Hour Format:"] = "Formato da Hora:"
     GRM_L["24 Hour"] = "24 Horas"
@@ -762,31 +708,16 @@ GRML.PortugueseBR = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = "|CFFE6CC7FClique|r para ordenar Datas de Promoção pela mais Antiga"
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = "|CFFE6CC7FClique|r para ordenar todos os Mains primeiro"
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = "|CFFE6CC7FClique|r para ordenar todos os Alts primeiro"
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = "Perfil de {name} está Sendo Construído. Um Momento..."
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = "Tem {num} jogadores solicitando entrada na guilda. Você só tem espaço para mais {custom1} amigos. Por Favor Considere limpar suas listas de amigos e recrutamento."
     GRM_L["{name}'s Alts"] = "Alts de {name}"                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = "Próximo"                                           -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = "Antes"                                       -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = "Não tem recrutas ONLINE no momento."
-    GRM_L["There are currently no more players in that direction."] = "Não tem mais jogadores atualmente naquela direção."
-    GRM_L["You have reached the end of the list"] = "Você alcançou o fim da lista"
-    GRM_L["You have reached the top of the list"] = "Você alcançou o topo da lista"
-    GRM_L["Auto Open Window"] = "Auto Abrir Janela"
-    GRM_L["Only if a player is online and you are not in combat"] = "Somente se um jogador estiver online e você não estiver em combate"
-    GRM_L["Recruit window will open when combat ends."] = "Janela de Recrute vai abrir quando sair de combate."
     GRM_L["GRM window will open when combat ends."] = "Janela do GRM vai abrir quando sair de combate."
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = "Entrou: {name}"                                                                 -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = "Auto-Detecção do GRM! {name} entrou na guilda e vai ser setado como Main"            -- Main auto-detect message
 
     -- R1.26
@@ -805,26 +736,15 @@ GRML.PortugueseBR = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = "Reset Total"
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = "Reset total de TODOS os dados do GRM. O jogo será recarregado!"
-    GRM_L["Reject\nAll"] = "Rejeitar\nTodos"                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = "{num} Candidatos para a Guilda foram negados"
-    GRM_L["Do you really want to reject all applicants?"] = "Você realmente quer rejeitar todos os candidatos?"
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = "Apenas recomendar expulsar se todos os alts vinculados do jogador excederem o tempo máximo"
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = "Seu Líder da Guilda Setou as Restrições de Sincronia para {name} ou Maior"
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = "Não foi possível Mudar o Cargo. Líder da Guilda setou a restrição para {name} ou maior"     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = "Não foi possível Mudar o Cargo. Líder da Guilda setou um nível de restrição"
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = "Unifique as Configurações de Controle para todos os membros com comandos 'g#^X'"
-    GRM_L["CONTROL TAGS:"] = "TAGS DE CONTROLE:"
     GRM_L["Force Settings with Guild Info Tags"] = "Forçar Configurações com Tags de Informações da Guilda"
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = "Aviso! Mensagens do Sistema foram desativadas! GRM não pode funcionar totalmente sem elas. Você deve re-habilitálas nas configurações de chat."
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = "Banco de Dados ainda Carregando. GRM vai abrir automaticamente quando terminar."
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = "Deseja mesmo convidar todos os candidatos?"
-    GRM_L["There are currently 0 players online to invite."] = "No momento, existem 0 jogadores online para convidar."
-    GRM_L["It appears all players are now offline."] = "Parece que todos os jogadores estão offline agora."
-    GRM_L["Invite\nAll"] = "Convidar\nTodos"                            -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = "Incluir Mensagem Quando Mandar Convite"
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = "Clique aqui para setar mensagem customizada de convite. Pressione Enter para salvar antes de mandar o convite!"
     GRM_L["The highlighted character is not valid for messages. Please remove."] = "O caractér destacado não é válido para mensagens. Por Favor remova."
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = "Nem todos os caractéres são válidos. Por Favor remova quaisquer caractéres que não sejam de texto."
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = "Macro de Expulsar criada. Pressione \"CTRL-SHIFT-K\" para expulsar todos os alts de {name}"
@@ -835,7 +755,6 @@ GRML.PortugueseBR = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = "Sincronização Com {name} está Completa..."
-    GRM_L["Database Still Loading. Please Wait..."] = "Banco de Dados Ainda Carregando. Por Favor Espere..."
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = "|CFFE6CC7FClique com o Esquerdo|r e arraste para mover esse botão."
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = "|CFFE6CC7FCtrl-Left-Clique|r e arraste para mover esse botão pra qualquer lugar."
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -845,15 +764,12 @@ GRML.PortugueseBR = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = "Mostrar Tag 'Main' em ambos Mains e Alts no Chat"
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = "Convites Sendo Enviados no Momento..."
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = "O GRM moveu os códigos de restrição de configuração do Líder da Guilda para a aba de Informações da Guilda."
     GRM_L["Please make room for them and re-add."] = "Por favor, abra espaço para mais e adicione novamente."
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = "Seu Líder da Guilda fez um reset dos seus dados."
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = "Seu Líder da Guilda Setou Restrições de Sincronia de BAN para {name} ou Maior"
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = "Seu Líder da Guilda Setou Restrições de Sincronia de NOTAS CUSTOMIZADAS para {name} ou Maior"
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = "Macro de Convidar todos criada. Pressione \"CTRL-SHIFT-K\" para convidar todos os recrutas online."
     GRM_L["Macro will auto-remove after {num} seconds."] = "Macro vai se auto-remover depois de {num} segundos."
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = "Controles da UI"
@@ -919,12 +835,10 @@ GRML.PortugueseBR = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = "{num} perfis de metadados estão sendo criados para pessoas previamente na guilda. Os dados estão sendo solicitados, mas isso pode levar algum tempo."                 -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = "{num} perfil de metadados esta sendo criado para um jogador previamente na guilda. Os dados estão sendo solicitados, mas isso pode levar algum tempo."           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = "A sincronização será acionada novamente uma vez, em um momento, para coletar dados finais sobre esses perfis."
     GRM_L["Auto-Focus the search box"] = "Auto-Focar a caixa de pesquisa"
     GRM_L["This will skip the first time if set to load on logon"] = "Isso pulará a primeira vez se definido para carregar ao entrar"  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = "Por Favor entre com um nível válido entre 1 e {num}"
     GRM_L["Player's Main: {name}"] = "Main do Jogador: {name}"
-    GRM_L["Player's main no longer in the guild: {name}"] = "Main do Jogador não está mais na guilda: {name}"
 
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = "Um momento, solicitando detalhes adicionais sobre {name} no servidor. A Lista de Ban será atualizada em breve."
@@ -960,7 +874,6 @@ GRML.PortugueseBR = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = "recrutas" 
     GRM_L["kick"] = "expulsar"
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -998,7 +911,6 @@ GRML.PortugueseBR = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = "| CFFE6CC7FShift-Clique | r o Segundo Botão para Selecionar Todos os Itens Intermediários"
     GRM_L["|CFFE6CC7FClick|r to select player"] = "|CFFE6CC7FClique|r para selecionar jogador"
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = "|CFFE6CC7FCtrl-Clique|r para abrir a Janela do Jogador"
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = "Por Favor Selecione sua guilda manualmente na Janela de Comunidade para que esse recurso funcione"
     GRM_L["Only Show Players With Incomplete Status"] = "Somente Mostrar Jogadores Com Status Incompleto"
     GRM_L["{num} Join Dates Need Attention"] = "{num} Datas de Entrada Precisam de Atenção"            -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = "Deseja mesmo remover as datas de entrada de outras notas que não sejam {nome}?"
@@ -1021,7 +933,6 @@ GRML.PortugueseBR = function()
     GRM_L["Mismatched dates"] = "Datas Incompatíveis"
     GRM_L["Matching date found in wrong note location"] = "Data Compatível achada em local errado da nota"
     GRM_L["Date not added to note"] = "Data não adicionada a nota"
-    GRM_L["Mismatched dates and found in wrong note location"] = "Datas Incompatíveis achadas, e encontradas em local errado da nota"
     GRM_L["Mismatched date found in multiple locations, including correct"] = "Data Incompatível achada em locais múltiplos, inclusive o certo"
     GRM_L["Mismatched date found in multiple incorrect note locations"] = "Data Incompatível achada em múltiplos locais incorretos de nota"
     GRM_L["Matching date found in multiple incorrect note locations"] = "Data Compatível achada em múltiplos locais errados da nota"
@@ -1038,16 +949,12 @@ GRML.PortugueseBR = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = "Mensagem de Log Completa:"
-    GRM_L["Public Notes"] = "Notas Públicas"
-    GRM_L["Officer Notes"] = "Notas Oficiais"
-    GRM_L["Custom Notes"] = "Notas Customizadas"
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = "1 entrada foi removida do registro"
     GRM_L["{num} entries have been removed from the log"] = "{num} entradaa foram removidas do registro"
     
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = "|CFFE6CC7FCtrl-Clique|r para abrir a Janela Antiga de Lista da Guilda"
-    GRM_L["Using the Old Guild Roster Interface instead"] = "Em vez disso, usando a Interface Antiga de Lista da Guilda"
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = "Adicionar a Data de Entrada não pode ser desativada devido à configuração global"
@@ -1100,8 +1007,6 @@ GRML.PortugueseBR = function()
     GRM_L["No Current Names to Add"] = "Nenhum Nome para Adicionar"
     GRM_L["No Names to Add to the Macro"] = "Nenhum Nome para Adicionar a Macro"
     GRM_L["Hot Key: {name}"] = "Tecla de Atalho: {name}"
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = "Pressione a Tecla de Atalho 1 vez para completar todas as ações"
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = "Pressione a Tecla de Atalho {num} vezes para completar todas as ações"
     GRM_L["Permissions"] = "Permissões"
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = "Mudança de Cargo de Jogador detectada, verificando novamente as permissões e reconstruindo a Ferramenta de Macro do GRM."
     GRM_L["Click to remove selected names from the macro"] = "Clique para remover os nomes selecionados da macro"          -- Plural form of statement
@@ -1164,7 +1069,6 @@ GRML.PortugueseBR = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = "Lista"
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = "|CFFE6CC7FCtrl-Clique|r para abrir a Janela de Lista da Guilda"
     GRM_L["Feature is disabled in WoW Classic"] = "Recurso desativado no WoW Clássico"
     GRM_L["Feature is disabled in TBC Classic"] = "Recurso desativado no TBC Clássico"          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = "Não há um calendário para adicionar eventos para"
@@ -1207,9 +1111,7 @@ GRML.PortugueseBR = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1240,7 +1142,6 @@ GRML.PortugueseBR = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1311,7 +1212,6 @@ GRML.PortugueseBR = function()
 
     -- 1.84
     GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-    GRM_L["{name} Rule {num}"] = true
     GRM_L["Apply Only to Selected Ranks"] = true
     GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
     GRM_L["No player data found, recommend full removal."] = true
@@ -1334,7 +1234,6 @@ GRML.PortugueseBR = function()
     GRM_L["Join Header"] = true;
     GRM_L["ReJoin Header"] = true;
     GRM_L["!note Control"] = true
-    GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
     GRM_L["You need to clear {num} characters to fit the control tags"] = true
     GRM_L["A new format exists for global settings controls."] = true
     GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1365,7 +1264,6 @@ GRML.PortugueseBR = function()
     
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1391,7 +1289,6 @@ GRML.PortugueseBR = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1419,7 +1316,6 @@ GRML.PortugueseBR = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1480,7 +1376,6 @@ GRML.PortugueseBR = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/Russian.lua
+++ b/locales/Russian.lua
@@ -79,7 +79,6 @@ GRML.Russian = function()
     GRM_L["Edit Promo Date"] = "Редактировать дату"
     GRM_L["Edit Join Date"] = "Редактировать дату"
     GRM_L["Set Promo Date"] = "Уст. дату"
-    GRM_L["In Group"] = "Уже в группе"                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = "Пригласить в группу"
     GRM_L["No Invite"] = "Не пригласть :("
     GRM_L["Group Invite"] = "Пригласить в группу"
@@ -93,7 +92,6 @@ GRML.Russian = function()
     GRM_L["Player Alts"] = "Твинки игрока"
     GRM_L["Add Alt"] = "Добавить твинка"
     GRM_L["Choose Alt"] = "Выберите твинка"
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = "Shift+ПКМ по имени в списке гильдии"
     GRM_L["Guild Log"] = "Гильд. Журнал"
     GRM_L["Guild"] = "Гильдия"
 
@@ -122,12 +120,9 @@ GRML.Russian = function()
     GRM_L["Guild Roster Event Log"] = "Журнал событий"
     GRM_L["Clear Log"] = "Очистить журнал"
     GRM_L["Really Clear the Guild Log?"] = "Уверены, что хотите очистить журнал гильдии?"
-    GRM_L["{name} DEMOTED {name2}"] = "{name} РАЗЖАЛОВАЛ {name2}"
-    GRM_L["{name} PROMOTED {name2}"] = "{name} ПОВЫСИЛ {name2}"
     GRM_L["{name} KICKED {name2} from the Guild!"] = "{name} ИСКЛЮЧИЛ игрока {name2} из гильдии"
     GRM_L["kicked"] = "исключен"
     GRM_L["{name} has Left the guild"] = "{name} вышел из гильдии"
-    GRM_L["{name} INVITED {name2} to the guild."] = "{name} Пригласил игрока {name2} в гильдию"
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = "{name} ЗАБАНИЛ игрока {name2} и всех его твинков в гильдие"
     GRM_L["{name} has BANNED {name2} from the guild!"] = "{name} ЗАБАНИЛ игрока {name2} в гильдии"
     GRM_L["Reason Banned:"] = "Причина БАНа"
@@ -157,7 +152,6 @@ GRML.Russian = function()
     GRM_L["{name} has JOINED the guild!"] = "{name} Присоединяется к гильдии"
     GRM_L["Date Left:"] = "Дата выхода:"
     GRM_L["{name} has Leveled to {num}"] = "{name} повысил уровень до {num}"
-    GRM_L["Leveled to"] = "Повысил уровень до"                                           -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = "(+{num} уровней)"                                        -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = "(+{num} уровень)"                                         -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = "ПУБЛИЧНАЯ заметка \"{custom1}\" игрока {name} добавлена"           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.Russian = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = "Гильдейское звание переименовано с {custom1} на {custom2}"
     GRM_L["{name} has Name-Changed to {name2}"] = "{name} переименовано на {name2}"
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = "{name} ВЕРНУЛСЯ игру после ОТСУТСТВИЯ втечение {num}"
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = "{name } кажется изменил имя, но новое имя трудно определить"
-    GRM_L["It Could Be One of the Following:"] = "Может быть одним из следующих:"
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = "{name} был ОФФЛАЙН в течении {num}. Рекомендуется исключить!"
     GRM_L["({num} ago)"] = "{num} спустя"    -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = "Гильдия \"{name}\" изменила имя на \"{name2}\""
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = "{name} празднует {num} год(а) в гильдии! ( {custom1} )" -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = "{name} празднует {num} лет в гильдии! ( {custom1} )"          -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = "Повышение"
     GRM_L["Demotions"] = "Разжалование"
 	
@@ -291,13 +281,10 @@ GRML.Russian = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = "Деактивация синхронизации данных в гильдиях..."
     GRM_L["Display Sync Update Messages"] = "Отображать сообщения о синхронизации"
     GRM_L["Only Sync With Up-to-Date Addon Users"] = "Синхронизироваться ТОЛЬКО с пользователями ПОСЛЕДНЕЙ версией аддона"
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = "Объявлять юбилеи только для Мейн персонажей"
     GRM_L["Leveled"] = "ЛВЛ Ап"
-    GRM_L["Min:"] = "Мин"                                   -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = "Возвращ. неактив."
     GRM_L["resetall"] = "СбросВсе"
     GRM_L["resetguild"] = "СбросГИ"
-    GRM_L["Notify When Players Request to Join the Guild"] = "Уведомлять о запросах присоединения в ГИ"
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = "Смена имени"
     GRM_L["Rank Renamed"] = "Переим. звания"
@@ -330,7 +317,6 @@ GRML.Russian = function()
     GRM_L["Join Date"] = "Дата вступления"
     GRM_L["Promo Date"] = "Дата повышения"
     GRM_L["Main/Alt"] = "Мейн/твинк"
-    GRM_L["Click Player to Edit"] = "ЛКМ для редакт."
     GRM_L["Only Show Incomplete Guildies"] = "Только неполные записи"
 
    -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.Russian = function()
     GRM_L["(Ver:"] = "(Версия:"                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = "ГРМ обновлен:"
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = "Настройка ГРМ для {name} в первый раз."
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = "Реактивация автоматического сканирования для поиска изменений в гильдии у игроков..."
-    GRM_L["Reactivating Data Sync..."] = "Реактивация синхронизации данных"
     GRM_L["Notification Set:"] = "Уведомление установлено:"
     GRM_L["Report When {name} is ACTIVE Again!"] = "Сообщать, когда {name} снова будет АКТИВНЫМ!"
     GRM_L["Report When {name} Comes Online!"] = "Сообщать, когда {name} снова будет в сети!"
@@ -350,10 +334,6 @@ GRML.Russian = function()
     GRM_L["Player Does Not Have a Time Machine!"] = "У игрока нет машины времени ;)"
     GRM_L["Please choose a valid DAY"] = "Пожалуйста, выберите правильный день"
     GRM_L["{name} has been Removed from the Ban List."] = "{name} был удален из запрещенного списка."
-    GRM_L["{num} Players Have Requested to Join the Guild."] = "{num} игроков попросились вступить в гильдию."
-    GRM_L["A Player Has Requested to Join the Guild."] = "Игрок попросился вступить в гильдию."
-    GRM_L["Click Link to Open Recruiting Window:"] = "Кликните по ссылке для открытия окна рекрутинга:"
-    GRM_L["Guild Recruits"] = "Рекруты гильдии"
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = "Сканирование гильдии на изменения. Один момент..."
     GRM_L["Breaking current Sync with {name}."] = "Синхронизация с {name} прервана!"
     GRM_L["Breaking current Sync with the Guild..."] = "Прервана текущая синхронизация с гильдией..."
@@ -361,8 +341,6 @@ GRML.Russian = function()
     GRM_L["No Players Currently Online to Sync With..."] = "В настоящее время нет игроков в игре для синхронизации..."
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = "В настоящее время нет игроков с аддоном для полной синхронизации"
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = "Синхронизация в настоящее время невозможна! Невозможно синхронизироваться с гильдией, когда чат гильдии недоступен."
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = "В настоящее время нет претендентов на вступление в гильдию."
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = "Список кандидатов недоступен без привилегий приглашения."
     GRM_L["Manual Scan Complete"] = "Ручное сканирование завершено"
     GRM_L["Analyzing guild for the first time..."] = "Инициализируем первый анализ гильдии..."
     GRM_L["Building Profiles on ALL \"{name}\" members"] = "Создание профилей для ВСЕХ \"{name}\" участников "                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.Russian = function()
     GRM_L["{name} is now OFFLINE!"] = "{name} вышел из игры!"
     GRM_L["{name} is No Longer AFK or Busy!"] = "Вернулся из АФК"
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = "Вернулся из АФК и вышел из сети"
-    GRM_L["{name} is Already in Your Group!"] = "{name} уже в вашей группе!"
-    GRM_L["GROUP NOTIFICATION:"] = "Групповое оповещение"
-    GRM_L["Players Offline:"] = "Игроков не в сети"
-    GRM_L["Players AFK:"] = "Игроков АФК"
-    GRM_L["40 players have already been invited to this Raid!"] = "В этот рейд уже приглашено 40 игроков!"
     GRM_L["Player should try to obtain group invite privileges."] = "Игрок должен получить привилегии группового приглашения."
     GRM_L["{name}'s saved data has been wiped!"] = "Данные пользователя {name} удалены!"
     GRM_L["Re-Syncing {name}'s Guild Data..."] = "Ресинхронизация {name} данных гильдии"
@@ -395,14 +368,12 @@ GRML.Russian = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = "Запускает повторную синхронизацию вручную, если синхронизация включена"
     GRM_L["Does a one-time manual scan for changes"] = "Выполняет одноразовое сканирование вручную на предмет изменений"
     GRM_L["Displays current Addon version"] = "Отображает текущую версию аддона"
-    GRM_L["Opens Guild Recruitment Window"] = "Открывает окно набора в гильдию"
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = "ПРЕДУПРЕЖДЕНИЕ! Полный сброс, включая все настройки, до состояния только что установленного аддона.";
 
     -- General Misc UI
     GRM_L["Really Clear All Account-Wide Saved Data?"] = "Вы действительно хотите очистить все сохраненные данные учетной записи?"
     GRM_L["Really Clear All Guild Saved Data?"] = "Вы действительно хотите очистить все сохраненные данные гильдии?"
     GRM_L["Yes!"] = "Да!"
-    GRM_L["<M>"] = "<M>"                           -- <M> appears for "Main"
     GRM_L["Ban Player?"] = "ЗаБАНить игрока?"
     GRM_L["Ban the Player's {num} alts too?"] = "ЗаБАНить также {num} твинков?"        -- Plural number of alts
     GRM_L["Ban the Player's {num} alt too?"] = "ЗаБАНить также {num} твинка?"     -- Singular number of alts, just 1
@@ -465,7 +436,6 @@ GRML.Russian = function()
     GRM_L["sync"] = "Синх"                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = "Скан"                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = "Сброс Все"                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = "Рекрут"                         -- Context: Open the roster "recruit" window where people request to join guild
 
       -- CLASSES
     GRM_L["Deathknight"] = "Рыцарь смерти"
@@ -561,13 +531,11 @@ GRML.Russian = function()
     GRM_L["Player is Not Currently in a Guild"] = "Игрок не состоит в гильдии"
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = "|CFFE6CC7FЛКМ|r для открытия ГРМ"                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = "|CFFE6CC7FЗажмите ПКМ|r и перемещайте эту кнопку."   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = "|CFFE6CC7FПКМ|r для сброса до 100%"                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = "|CFFE6CC7FПКМ|r для синхронизации даты вступления с твинками"
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = "|CFFE6CC7FПКМ|r для установки уведомления об изменении статуса"
     -- tooltip end
     GRM_L["GRM"] = "ГРМ"
-    GRM_L["<A>"] = "<Тв>"                                                     -- This is the "Alt" tag on the Add Alt side window.
     GRM_L["Include Unknown as Incomplete"] = "Считать \"Неизвестно\" как неполные" -- Context: Unknown in the Audit Tab will be hidden if filtering out complete players
     GRM_L["You Do Not Have Permission to Add Events to Calendar"] = "У тебя не прав для создания события в календаре"
     GRM_L["Please Select Which Join Date to Sync"] = "Пожалуйста, выберите дату присоединения для синхронизации"
@@ -613,7 +581,6 @@ GRML.Russian = function()
     GRM_L["{name} has been removed from the database."] = "{name} был удален из базы данных."            -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = "Вы по-прежнему будете делиться своими данными с гильдией, но в настоящее время вы принимаете входящие изменения только от звания \"{name}\" или выше"    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = "Не принимать данные от игроков, ниже данного звания"
     GRM_L["Total Entries: {num}"] = "Всего записей: {num}"
     GRM_L["Search Filter"] = "Поиск"
@@ -646,9 +613,6 @@ GRML.Russian = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = "В настоящее время у вас {num} друзей, без Battletag'a. Чтобы в полной мере воспользоваться всеми функциями ГРМ, рассмотрите возможность освобождения места."
-    GRM_L["Clear Space on Friends List to Find Online Status"] = "Очистите место в списке друзей, чтобы узнать статус в сети"
-    GRM_L["Offline"] = "Не в сети"
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = "{name} подал заявку на вступление в гильдию и сейчас находится в сети!"
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = "Вы действительно хотите очистить строку {num}?"
@@ -659,7 +623,6 @@ GRML.Russian = function()
     GRM_L["Right-Click to Reset to 100%"] = "|CFFE6CC7FПКМ|r для сброса до 100%"
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = "|CFFE6CC7FЛКМ|r для открытия окна игрока"
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = "|CFFE6CC7FCtrl-Shift-ЛКМ|r для поиска игрока в журнале"
 
     -- Update 1.1480
@@ -673,20 +636,15 @@ GRML.Russian = function()
     GRM_L["Sync Custom Notes"] = "Синхронизировать Пользовательские заметки"
     GRM_L["Default Custom Note Rank Minimum"] = "Минимальное звание для импорта Пользовательских заметок"
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = "Сбросить минимальное звание для импорта Доп.Заметками для всей ГИ"
-    GRM_L["Reset to Default"] = "Сбросить до стандартных"
     GRM_L["Reset"] = "Сбросить"
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = "|CFF00CCFFПо умолчанию для всех игроков"
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = "Если синхронизация была отключена вручную для определенных гильдий, это НЕ включает ее."
-    GRM_L["Custom note Sync has been reset to default"] = "Синхронизация пользовательских заметок сброшена по умолчанию"
     GRM_L["Click here to set Custom Notes"] = "Нажмите, для установки пользовательской заметки"
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = "|CFF00CCFFПользовательские заметки по умолчанию"
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = "|CFFE6CC7FЛКМ|r чтобы повторно включить синхронизацию пользовательских заметок для всех"
-    GRM_L["Custom Note Sync Disabled in Settings"] = "Пользовательская синхронизация заметок отключена в настройках"
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = "{name} добавил пользовательскую заметку игроку {name2}: \"{custom1}\""
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = "{name} удалил пользовательскую заметку игроку {name2}: \"{custom1}\""
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = "{name} изменил пользовательскую заметку игроку {name2}: с \"{custom1}\" на \"{custom2}\""
     GRM_L["Custom Note"] = "Пользовательская заметка"
-    GRM_L["Syncing Outgoing Data."] = "Синхронизация исходящих данных."
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = "|CFFE6CC7FЛКМ|r чтобы изменить ограничение звания"
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = "|CFFE6CC7FЛКМ|r чтобы выбрать ДЕНЬ" 
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = "|CFFE6CC7FЛКМ|r чтобы выбрать МЕСЯЦ" 
@@ -706,10 +664,6 @@ GRML.Russian = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = "|CFFE6CC7FЛКМ|r для выбора языка"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = "|CFFE6CC7FЛКМ|r для выбора формата"
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = "|CFFE6CC7FЛКМ|r для выбора шрифта"
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = "К сожалению, данные каждого игрока придется перенастроить вручную."
-    GRM_L["{num} custom {custom1} removed that matched text:"] = "{num} пользователь {custom1} удалил совпадающий текст:"                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = "Заметки"
-    GRM_L["Please add specific text, in quotations, to match"] = "Пожалуйста, добавьте конкретный текст в кавычках для соответствия"
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = "Вы по-прежнему будете делиться исходящими данными с гильдией"
@@ -721,8 +675,6 @@ GRML.Russian = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = "Используйте только как оценку. Надеюсь, Blizz скоро это исправит"
     GRM_L["{name}'s Anniversary!"] = "Сегодня годовщина у {name}!"
     GRM_L["{name}'s Birthday!"] = "Сегодня День Рождения у {name}!"
-    GRM_L["Guild member for over {num} year"] = "Член гильдии более {num} года"
-    GRM_L["Guild member for over {num} years"] = "Член гильдии более {num} лет"   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = "Добавить предстоящие события в календарь"
     GRM_L["Player rank unable to add events to calendar"] = "Звание игрока не достаточно что-бы добавлять события в календарь"
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = "Годовщины, дни рождения и другие события могут быть добавлены с разрешения"
@@ -731,7 +683,6 @@ GRML.Russian = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = "Проверьте вкладку \"Синхронизация пользователей \", чтобы узнать почему!"
     GRM_L["Time as Member:"] = "Время членства"
     GRM_L["|CFFE6CC7FClick|r to select player event"] = "|CFFE6CC7FЛКМ|r для выбора события игрока"
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = "|CFFE6CC7FЛКМ ещё раз|r для открытия окна игрока"
     GRM_L["Timestamp Format:"] = "Формат даты:"
     GRM_L["Hour Format:"] = "Формат времени:"
     GRM_L["24 Hour"] = "24 часа"
@@ -765,31 +716,16 @@ GRML.Russian = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = "|CFFE6CC7FЛКМ|r сортировать даты повышения по самым старым"
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = "|CFFE6CC7FЛКМ|r для сортировки всех Мейнов первыми"
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = "|CFFE6CC7FЛКМ|r для сортировки всех твинков первыми"
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = "Профиль пользователя {name} находится в стадии создания. Один момент..."
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = "{Num} игроков просят вступить в вашу гильдию. У вас есть место только для {custom1} согильдейцев. Пожалуйста, подумайте о том, чтобы подчистить список гильдии.";
     GRM_L["{name}'s Alts"] = "Твинки {name}"          -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = "В сети:  {num}/{custom1}"    -- As in "Online: 3/59"
-    GRM_L["Next"] = "Следующий "         -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = "Предыдущий "          -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = "В настоящее время в сети нет новобранцев."
-    GRM_L["There are currently no more players in that direction."] = "В настоящее время в этом направлении больше нет игроков."
-    GRM_L["You have reached the end of the list"] = "Вы достигли конца списка"
-    GRM_L["You have reached the top of the list"] = "Вы достигли начала списка"
-    GRM_L["Auto Open Window"] = "Автооткрытие окна"
-    GRM_L["Only if a player is online and you are not in combat"] = "Только если игрок онлайн, а вы не в бою"
-    GRM_L["Recruit window will open when combat ends."] = "Окно найма откроется, когда закончится бой."
     GRM_L["GRM window will open when combat ends."] = "Окно ГРМ откроется по окончанию боя."
 	
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = "Это также изменит формат <Твинк> для соответствия"
     GRM_L["M"] = "М"                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = "Тв"           
-    GRM_L["<M>"] = "<М>"                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = "<Тв>"                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = "Включите тег \"Присоединяется:\" с датой."                                    -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = "Присоединяется: {name}"                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = "ГРМ Авто-обнаружение! {name} вступил в гильдию и будет назначен Мейном"            -- Main auto-detect message
 
     -- R1.26
@@ -808,30 +744,15 @@ GRML.Russian = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = "Отображение публичных, офицерских и пользовательских заметок в записях журнала вышедших игроков"
     GRM_L["Hard Reset"] = "Полный сброс"
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = "Полный сброс ВСЕХ данных ГРМ для всей учетной записи. Игра перезагрузится!"
-    GRM_L["Reject\nAll"] = "Отклонить\nВсе"                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = "{num} кандидатам в Гильдию отказано"
-    GRM_L["Do you really want to reject all applicants?"] = "Вы действительно хотите отклонить всех кандитатов?"
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = "Рекомендовать только исключение, если все игроки связанные с твинками превышают максимальное время"
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = "Лидер вашей гильдии установил ограничения синхронизации на {name} или выше"
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = "Невозможно изменить звание. Лидер гильдии установил ограничение до {name} или выше"     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = "Невозможно изменить звание. Лидер гильдии установил уровень ограничения."
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = "Унифицируйте настройки управления для всех гильдий с помощью команд 'g#^X'"
-    GRM_L["CONTROL TAGS:"] = "МЕТКИ КОНТРОЛЯ:"
     GRM_L["Force Settings with Guild Info Tags"] = "Принудительные настройки с помощью тегов в информации о гильдии"
-    GRM_L["X = index of minimum rank. Example: 0 = {name} and {num} = {name2}"] = "X = индекс минимального звания. Пример: 0 = {name} и {num} = {name2}"
-    GRM_L["'g2^X' - Establish minimum sync rank restriction for player details"] = "'g2^X' - установить минимальное ограничение для звания синхронизации сведений об игроке"
-    GRM_L["'g3^X' - Establish minimum sync rank restriction for BAN info"] = "'g3^X' - установить ограничение минимального звания для синхронизации информации о банах"
-    GRM_L["'g4^X' - Establish minimum sync rank restriction for Custom Note info"] = "'g4^X' - установить ограничение минимального звания для синхронизации информации о пользовательской заметке."
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = "Предупреждение! Системные сообщения отключены! Без них ГРМ не может полноценно функционировать. Вы должны повторно включить их в настройках чата."
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = "База данных все еще загружается. ГРМ откроется автоматически по завершении."
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = "Вы действительно хотите пригласить всех кандидатов?"
-    GRM_L["There are currently 0 players online to invite."] = "Сейчас онлайн 0 игроков, которых можно пригласить."
-    GRM_L["It appears all players are now offline."] = "Похоже, все игроки сейчас не в сети."
-    GRM_L["Invite\nAll"] = "Пригласить\nвсех"                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = "Включить сообщение при отправке приглашения"
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = "Щелкните здесь, чтобы настроить сообщение для приглашения. Перед отправкой приглашения нажмите Enter, чтобы сохранить!"
     GRM_L["The highlighted character is not valid for messages. Please remove."] = "Введенный символ недопустим для сообщений. Пожалуйста, удалите."
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = "Не все символы корректны. Удалите все нетекстовые символы."
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = "Создан макрос для исключения. Нажмите \"CTRL-SHIFT-K\", чтобы удалить всех твинков игрока {name}."
@@ -842,7 +763,6 @@ GRML.Russian = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = "Синхронизация с {name} завершена..."
-    GRM_L["Database Still Loading. Please Wait..."] = "База данных все еще загружается. Пожалуйста, подождите..."
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = "|CFFE6CC7FЛКМ|r и перемещайте эту кнопку."
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = "|CFFE6CC7FCtrl-ЛКМ|r и перемещайте эту кнопку куда угодно."
     GRM_L["MOTD:"] = "Сообщение дня"      -- Message Of The Day = M.O.T.D = MOTD - 
@@ -852,15 +772,12 @@ GRML.Russian = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = "Показывать 'Мейн' и 'Твинк' тег в чате"
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = "Приглашения, отправленные в настоящее время..."
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = "ГРМ переместил коды ограничений настройки лидера гильдии на вкладку «Информация о гильдии»."
     GRM_L["Please make room for them and re-add."] = "Пожалуйста, освободите для них место и добавьте заново."
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = "Ваш Лидер гильдии сбросил ваши данные.";
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = "Ваш Лидер гильдии установил ограничения на синхронизацию банов на {name} или выше"
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = "Ваш Лидер гильдии установил ограничения на синхронизацию Пользовательсих заметок на {name} или выше"
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = "Для приглашения всех создан макрос. Нажмите \"CTRL-SHIFT-K\", чтобы пригласить всех онлайн новобранцев."
     GRM_L["Macro will auto-remove after {num} seconds."] = "Макрос будет автоматически удален через {num} секунд."
     GRM_L["UI"] = "UI"
     GRM_L["UI Controls"] = "Управление интерфейсом"
@@ -926,12 +843,10 @@ GRML.Russian = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = "Профили метаданных {num} создаются для людей, ранее состоявших в гильдии. Данные запрашиваются, но это может занять некоторое время."                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = "Один профиль метаданных создается для игрока, ранее состоявшего в гильдии. Данные запрашиваются, но это может занять некоторое время."           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = "Синхронизация будет перезапущена один раз в мгновение ока, чтобы собрать окончательные данные по этим профилям."
     GRM_L["Auto-Focus the search box"] = "Автофокусировка окна поиска"
     GRM_L["This will skip the first time if set to load on logon"] = "Это будет пропущено в первый раз, если установлено для загрузки при входе в систему"  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = "Введите допустимый уровень от 1 до {num}"
     GRM_L["Player's Main: {name}"] = "Мейн игрока: {name}"
-    GRM_L["Player's main no longer in the guild: {name}"] = "Мейн игрока больше не состоит в гильдии: {name}"
     
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = "Минутку, запрос дополнительных сведений о {name} с сервера. Список банов скоро будет обновлен."
@@ -967,7 +882,6 @@ GRML.Russian = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = "Новобранцы"
     GRM_L["kick"] = "Кик"
     GRM_L["ban"] = "Бан"
     GRM_L["audit"] = "Аудит"
@@ -1005,7 +919,6 @@ GRML.Russian = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = "|CFFE6CC7FShift-Клик|r Вторая кнопка для выбора всего промежуточного"
     GRM_L["|CFFE6CC7FClick|r to select player"] = "|CFFE6CC7FКлик|r для выбора игрока"
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = "|CFFE6CC7FCtrl-Клик|r для открытия окна игрока"
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = "Пожалуйста, вручную выберите вашу гильдию в окне сообщества, чтобы эта функция работала"
     GRM_L["Only Show Players With Incomplete Status"] = "Показывать только игроков с неполным статусом"
     GRM_L["{num} Join Dates Need Attention"] = "{num} дат регистраций требуют внимания"             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = "Вы действительно хотите удалить даты присоединения из других заметок, кроме {name}?"
@@ -1045,16 +958,12 @@ GRML.Russian = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = "Сообщение полного журнала:"
-    GRM_L["Public Notes"] = "Публичные заметки"
-    GRM_L["Officer Notes"] = "Офицерские заметки"
-    GRM_L["Custom Notes"] = "Пользовательские заметки"
     GRM_L["Log Entry Tooltip"] = "Подсказка о записи в журнале"
     GRM_L["1 entry has been removed from the log"] = "1 запись удалена из журнала"
     GRM_L["{num} entries have been removed from the log"] = "{num} записей(си) были удалены из журнала"
     
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = "|CFFE6CC7FCtrl-Клик|r, чтобы открыть окно состава старой версии гильдии"
-    GRM_L["Using the Old Guild Roster Interface instead"] = "Вместо этого используйте интерфейс старого состава гильдии"
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = "Добавление даты присоединения нельзя отключить из-за глобальной настройки"
@@ -1107,8 +1016,6 @@ GRML.Russian = function()
     GRM_L["No Current Names to Add"] = "Нет подходящих имен для добавления"
     GRM_L["No Names to Add to the Macro"] = "Нет имен для добавления к макросу"
     GRM_L["Hot Key: {name}"] = "Горячая клавиша: {name}"
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = "Нажмите Горячую клавишу 1 раз, чтобы завершить все действия"
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = "Нажмите горячую клавишу {num} раз, чтобы завершить все действия."
     GRM_L["Permissions"] = "Возможные действия"
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = "Обнаружено изменение рейтинга игроков, повторная проверка разрешений и восстановление ГРМ макро-тулза."
     GRM_L["Click to remove selected names from the macro"] = "Нажмите, чтобы удалить выбранные имена из макроса"           -- Plural form of statement
@@ -1171,7 +1078,6 @@ GRML.Russian = function()
     -- CLASSIC
     GRM_L["Social"] = "Социальное"
     GRM_L["Roster"] = "Состав"
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = "|CFFE6CC7FCtrl-Клик|r чтобы открыть окно списка гильдии"
     GRM_L["Feature is disabled in WoW Classic"] = "Функция отключена в WoW Classic"
     GRM_L["Feature is disabled in TBC Classic"] = "Функция отключена в WoW TBC"        -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = "Нет календаря для добавления событий"
@@ -1214,9 +1120,7 @@ GRML.Russian = function()
     GRM_L["!note"] = "!note"               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = "Нет в сети офицера, который мог бы добавить заметку {name}"
     GRM_L["No officer is currently online to update your note"] = "В настоящее время нет офицеров, которые могли бы обновить вашу заметку"
-    GRM_L["Note updated by @{name}"] = "Заметка обновлена @{name}"              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = "Разрешить членам гильдии набирать \"!note\" для создания собственной публичной заметки"
-    GRM_L["'!note' trigger has been globally enabled"] = "Триггер '!note' был включен глобально"
     GRM_L["Enabled"] = "Включено"         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = "Триггер '!note' глобально ВКЛЮЧЕН"
     GRM_L["'!note' trigger has been globally DISABLED"] = "Триггер '!note' глобально ОТКЛЮЧЕН"
@@ -1247,7 +1151,6 @@ GRML.Russian = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = "*Максимальный экспорт - 500 записей журнала за раз"
 	GRM_L["*Max Export is 500 Members at a Time"] = "*Максимальный экспорт - 500 участников за раз"
 	GRM_L["*Max Export is 500 Former Members at a Time"] = "*Максимальный экспорт - 500 бывших участников за раз"
-	GRM_L["Log export follows the search and display settings"] = "Экспорт журнала следует за настройками поиска и отображения"
 	GRM_L["*Export obeys the current log display filters"] = "*Экспорт подчиняется фильтрам отображения текущего журнала"
 	GRM_L["Select Line Range:"] = "Выберите диапазон строк:"
 	GRM_L["Select Member Range:"] = "Выберите диапазон членов:"
@@ -1318,7 +1221,6 @@ GRML.Russian = function()
 
      -- 1.84
      GRM_L["The note is too long. Only the first {num} characters will be set."] = "Заметка слишком длинная. Будут установлены только первые {число} символов."
-     GRM_L["{name} Rule {num}"] = "{name} Правило {num}"
      GRM_L["Apply Only to Selected Ranks"] = "Применить только к выбранным званиям"
      GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = "Невозможно создать макрос горячих клавиш. Игрок сейчас находится в бою, и действия ограничены. Он будет автоматически построен после выхода из боя."
      GRM_L["No player data found, recommend full removal."] = "Данные игрока не найдены, рекомендуется полное удаление."
@@ -1341,7 +1243,6 @@ GRML.Russian = function()
      GRM_L["Join Header"] = "Присоединиться к заголовку";
      GRM_L["ReJoin Header"] = "Перезаход в ги";
      GRM_L["!note Control"] = "!note контроль"
-     GRM_L["(default)"] = "(по умолчанию)"          -- as in, this setting is the DEFAULT setting.  Setting (default)
      GRM_L["You need to clear {num} characters to fit the control tags"] = "Необходимо очистить символы {num}, чтобы они соответствовали тегам управления."
      GRM_L["A new format exists for global settings controls."] = "Для элементов управления глобальными настройками существует новый формат."
      GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = "Перейдите в окно ГРМ> Параметры> вкладка Офицер> \"Установить глобальные элементы управления\""
@@ -1372,7 +1273,6 @@ GRML.Russian = function()
      
     -- R1.87
     GRM_L["Kick Rule {num}"] = "Условие исключения {num}"        -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = "Изменить пользовательское правило"
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = "|CFFE6CC7FНажмите ЛКМ|r для выключения правила"
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = "|CFFE6CC7FНажмите ЛКМ|r для включения правила"
     GRM_L["Edit"] = "Изменить"
@@ -1398,7 +1298,6 @@ GRML.Russian = function()
     GRM_L["Note match: {name}"] = "Соответствие заметки: {name}"                               -- Same
     GRM_L["Matching Rank"] = "Соответствующее звание"                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = "Щелкните ПКМ|r, чтобы изменить или удалить пользовательское правило"         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = "Игрок {name} соответствует параметрам {num} правилам вашего макро-тулза. Исключение рекомендуется!"
     GRM_L["|CFFE6CC7FClick|r to Change"] = "|CFFE6CC7FНажмите|r для изменения"
     GRM_L["(Applies Only to Classic)"] = "(Только для классической версии)"           -- For the Options... rather than removing them all
     
@@ -1426,7 +1325,6 @@ GRML.Russian = function()
     GRM_L["Enable Module"] = "Включить модуль"
     GRM_L["Show Interactable Distance Indicator"] = "Показать интерактивный индикатор расстояния"
     GRM_L["No GRM Modules Currently Installed"] = "В настоящее время модули для ГРМ не установлены"
-    GRM_L["Recruitment"] = "Вербовка"
     GRM_L["Pending Feature"] = "Будущая функция" 
     GRM_L["Custom Color"] = "Пользовательский цвет"
     GRM_L["{name} is listed as the Main"] = "{name} указан как Мейн"
@@ -1487,7 +1385,6 @@ GRML.Russian = function()
     GRM_L["Notify if at Rank for {num} {name}"] = "Сообщите, если в звании для {num} {name}"      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = "Гильдейская репутация игрока"         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = "|CFFE6CC7FЛКМ|r для изменения репутации"
-    GRM_L["Guild Rep: {name}"] = "Гильдейская репутация: {name}"
     GRM_L["Guild Rep:"] = "Гильдейская репутация:"
     GRM_L["Guild Rep lower than {name}"] = "Гильдейская репутация ниже, чем {name}"
     GRM_L["Guild Rep equal to {name}"] = "Гильдейская репутация равна {name}"

--- a/locales/SpanishEU.lua
+++ b/locales/SpanishEU.lua
@@ -79,7 +79,6 @@ GRML.SpanishEU = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.SpanishEU = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
 
@@ -122,12 +120,9 @@ GRML.SpanishEU = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.SpanishEU = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.SpanishEU = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.SpanishEU = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.SpanishEU = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.SpanishEU = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.SpanishEU = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.SpanishEU = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.SpanishEU = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.SpanishEU = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.SpanishEU = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "Caballero de la Muerte"
@@ -560,7 +531,6 @@ GRML.SpanishEU = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.SpanishEU = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.SpanishEU = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.SpanishEU = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.SpanishEU = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -703,10 +663,6 @@ GRML.SpanishEU = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -718,8 +674,6 @@ GRML.SpanishEU = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -728,7 +682,6 @@ GRML.SpanishEU = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -762,31 +715,16 @@ GRML.SpanishEU = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -805,30 +743,15 @@ GRML.SpanishEU = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
-    GRM_L["X = index of minimum rank. Example: 0 = {name} and {num} = {name2}"] = true
-    GRM_L["'g2^X' - Establish minimum sync rank restriction for player details"] = true
-    GRM_L["'g3^X' - Establish minimum sync rank restriction for BAN info"] = true
-    GRM_L["'g4^X' - Establish minimum sync rank restriction for Custom Note info"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -839,7 +762,6 @@ GRML.SpanishEU = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -849,15 +771,12 @@ GRML.SpanishEU = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -923,12 +842,10 @@ GRML.SpanishEU = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
     
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -964,7 +881,6 @@ GRML.SpanishEU = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -1002,7 +918,6 @@ GRML.SpanishEU = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1042,16 +957,12 @@ GRML.SpanishEU = function()
     
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
     
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1104,8 +1015,6 @@ GRML.SpanishEU = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1168,7 +1077,6 @@ GRML.SpanishEU = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1211,9 +1119,7 @@ GRML.SpanishEU = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1244,7 +1150,6 @@ GRML.SpanishEU = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1315,7 +1220,6 @@ GRML.SpanishEU = function()
 
      -- 1.84
      GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-     GRM_L["{name} Rule {num}"] = true
      GRM_L["Apply Only to Selected Ranks"] = true
      GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
      GRM_L["No player data found, recommend full removal."] = true
@@ -1338,7 +1242,6 @@ GRML.SpanishEU = function()
      GRM_L["Join Header"] = true;
      GRM_L["ReJoin Header"] = true;
      GRM_L["!note Control"] = true
-     GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
      GRM_L["You need to clear {num} characters to fit the control tags"] = true
      GRM_L["A new format exists for global settings controls."] = true
      GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1369,7 +1272,6 @@ GRML.SpanishEU = function()
     
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1395,7 +1297,6 @@ GRML.SpanishEU = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1423,7 +1324,6 @@ GRML.SpanishEU = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1484,7 +1384,6 @@ GRML.SpanishEU = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true

--- a/locales/SpanishMX.lua
+++ b/locales/SpanishMX.lua
@@ -79,7 +79,6 @@ GRML.SpanishMX = function()
     GRM_L["Edit Promo Date"] = true
     GRM_L["Edit Join Date"] = true
     GRM_L["Set Promo Date"] = true
-    GRM_L["In Group"] = true                            -- Context: "Player is already In Group with you"
     GRM_L["Group Invite"] = true
     GRM_L["No Invite"] = true
     GRM_L["Group Invite"] = true
@@ -93,7 +92,6 @@ GRML.SpanishMX = function()
     GRM_L["Player Alts"] = true
     GRM_L["Add Alt"] = true
     GRM_L["Choose Alt"] = true
-    GRM_L["Shift-Mouseover Name On Roster Also Works"] = true
     GRM_L["Guild Log"] = true
     GRM_L["Guild"] = true
     
@@ -122,12 +120,9 @@ GRML.SpanishMX = function()
     GRM_L["Guild Roster Event Log"] = true
     GRM_L["Clear Log"] = true
     GRM_L["Really Clear the Guild Log?"] = true
-    GRM_L["{name} DEMOTED {name2}"] = true
-    GRM_L["{name} PROMOTED {name2}"] = true
     GRM_L["{name} KICKED {name2} from the Guild!"] = true
     GRM_L["kicked"] = true
     GRM_L["{name} has Left the guild"] = true
-    GRM_L["{name} INVITED {name2} to the guild."] = true
     GRM_L["{name} has BANNED {name2} and all linked alts from the guild!"] = true
     GRM_L["{name} has BANNED {name2} from the guild!"] = true
     GRM_L["Reason Banned:"] = true
@@ -157,7 +152,6 @@ GRML.SpanishMX = function()
     GRM_L["{name} has JOINED the guild!"] = true
     GRM_L["Date Left:"] = true
     GRM_L["{name} has Leveled to {num}"] = true
-    GRM_L["Leveled to"] = true                                             -- For parsing the message, please include the string found in previous "has leveled to" message
     GRM_L["(+{num} levels)"] = true                                         -- Context: Person gained more than one level, hence the plural
     GRM_L["(+{num} level)"] = true                                          -- Context: Person gains a level, just one level.
     GRM_L["{name}'s PUBLIC Note: \"{custom1}\" was Added"] = true           -- Of note, the \" in the text here will just appear as " in-game. The \" notation is telling the program not to end the string, but to include quotation
@@ -169,13 +163,9 @@ GRML.SpanishMX = function()
     GRM_L["Guild Rank Renamed from {custom1} to {custom2}"] = true
     GRM_L["{name} has Name-Changed to {name2}"] = true
     GRM_L["{name} has Come ONLINE after being INACTIVE for {num}"] = true
-    GRM_L["{name } Seems to Have Name-Changed, but their New Name was Hard to Determine"] = true
-    GRM_L["It Could Be One of the Following:"] = true
     GRM_L["{name} has been OFFLINE for {num}. Kick Recommended!"] = true
     GRM_L["({num} ago)"] = true                                             -- Context: (5 minutes ago) or (5 months 24 days ago) -- the {num} will automatically include the time-passed date.
     GRM_L["{name}'s Guild has Name-Changed to \"{name2}\""] = true
-    GRM_L["{name} will be celebrating {num} year in the Guild! ( {custom1} )"] = true            -- {custom1} will reference the DATE. Ex: "Arkaan will be celebrating 1 year in the Guild! ( 1 May )" - SINGULAR
-    GRM_L["{name} will be celebrating {num} years in the Guild! ( {custom1} )"] = true           -- Same thing but PLURAL - "years" in stead of "year"
     GRM_L["Promotions"] = true
     GRM_L["Demotions"] = true
 
@@ -291,13 +281,10 @@ GRML.SpanishMX = function()
     GRM_L["Deactivating Data SYNC with Guildies..."] = true
     GRM_L["Display Sync Update Messages"] = true
     GRM_L["Only Sync With Up-to-Date Addon Users"] = true
-    GRM_L["Only Announce Anniversaries if Listed as 'Main'"] = true
     GRM_L["Leveled"] = true
-    GRM_L["Min:"] = true                                    -- Context: As in, the Minimum level to report or announce when player levels up
     GRM_L["Inactive Return"] = true
     GRM_L["resetall"] = true
     GRM_L["resetguild"] = true
-    GRM_L["Notify When Players Request to Join the Guild"] = true
     --Side chat/log controls - Of note, limited spacing
     GRM_L["Name Change"] = true
     GRM_L["Rank Renamed"] = true
@@ -330,7 +317,6 @@ GRML.SpanishMX = function()
     GRM_L["Join Date"] = true
     GRM_L["Promo Date"] = true
     GRM_L["Main/Alt"] = true
-    GRM_L["Click Player to Edit"] = true
     GRM_L["Only Show Incomplete Guildies"] = true
 
     -- ADDON SYSTEM MESSAGES
@@ -339,8 +325,6 @@ GRML.SpanishMX = function()
     GRM_L["(Ver:"] = true                                                               -- Ver: is short for Version:
     GRM_L["GRM Updated:"] = true
     GRM_L["Configuring Guild Roster Manager for {name} for the first time."] = true
-    GRM_L["Reactivating Auto SCAN for Guild Member Changes..."] = true
-    GRM_L["Reactivating Data Sync..."] = true
     GRM_L["Notification Set:"] = true
     GRM_L["Report When {name} is ACTIVE Again!"] = true
     GRM_L["Report When {name} Comes Online!"] = true
@@ -350,10 +334,6 @@ GRML.SpanishMX = function()
     GRM_L["Player Does Not Have a Time Machine!"] = true
     GRM_L["Please choose a valid DAY"] = true
     GRM_L["{name} has been Removed from the Ban List."] = true
-    GRM_L["{num} Players Have Requested to Join the Guild."] = true
-    GRM_L["A Player Has Requested to Join the Guild."] = true
-    GRM_L["Click Link to Open Recruiting Window:"] = true
-    GRM_L["Guild Recruits"] = true
     GRM_L["Scanning for Guild Changes Now. One Moment..."] = true
     GRM_L["Breaking current Sync with {name}."] = true
     GRM_L["Breaking current Sync with the Guild..."] = true
@@ -361,8 +341,6 @@ GRML.SpanishMX = function()
     GRM_L["No Players Currently Online to Sync With..."] = true
     GRM_L["No Addon Users Currently Compatible for FULL Sync."] = true
     GRM_L["SYNC is currently not possible! Unable to Sync with guildies when guild chat is restricted."] = true
-    GRM_L["There are No Current Applicants Requesting to Join the Guild."] = true
-    GRM_L["The Applicant List is Unavailable Without Having Invite Privileges."] = true
     GRM_L["Manual Scan Complete"] = true
     GRM_L["Analyzing guild for the first time..."] = true
     GRM_L["Building Profiles on ALL \"{name}\" members"] = true                 -- {name} will be the Guild Name, for context
@@ -371,11 +349,6 @@ GRML.SpanishMX = function()
     GRM_L["{name} is now OFFLINE!"] = true
     GRM_L["{name} is No Longer AFK or Busy!"] = true
     GRM_L["{name} is No Longer AFK or Busy, but they Went OFFLINE!"] = true
-    GRM_L["{name} is Already in Your Group!"] = true
-    GRM_L["GROUP NOTIFICATION:"] = true
-    GRM_L["Players Offline:"] = true
-    GRM_L["Players AFK:"] = true
-    GRM_L["40 players have already been invited to this Raid!"] = true
     GRM_L["Player should try to obtain group invite privileges."] = true
     GRM_L["{name}'s saved data has been wiped!"] = true
     GRM_L["Re-Syncing {name}'s Guild Data..."] = true
@@ -395,7 +368,6 @@ GRML.SpanishMX = function()
     GRM_L["Triggers manual re-sync if sync is enabled"] = true
     GRM_L["Does a one-time manual scan for changes"] = true
     GRM_L["Displays current Addon version"] = true
-    GRM_L["Opens Guild Recruitment Window"] = true
     GRM_L["WARNING! complete hard wipe, including settings, as if addon was just installed."] = true;
 
     -- General Misc UI
@@ -464,7 +436,6 @@ GRML.SpanishMX = function()
     GRM_L["sync"] = true                            -- Context: "sync" the data between players one time now.
     GRM_L["scan"] = true                            -- Context: "scan" for guild roster changes one time now.
     GRM_L["clearall"] = true                        -- Context: In regards, "Clear All" saved data
-    GRM_L["recruit"] = true                         -- Context: Open the roster "recruit" window where people request to join guild
 
     -- CLASSES
     GRM_L["Deathknight"] = "Caballero de la Muerte"
@@ -560,7 +531,6 @@ GRML.SpanishMX = function()
     GRM_L["Player is Not Currently in a Guild"] = true
     -- tooltips
     GRM_L["|CFFE6CC7FClick|r to open GRM"] = true                           -- Please maintain the color coding
-    GRM_L["|CFFE6CC7FRight-Click|r and drag to move this button."] = true   -- Likewise, maintain color coding
     GRM_L["|CFFE6CC7FRight-Click|r to Reset to 100%"] = true                -- for the Options slider tooltip
     GRM_L["|CFFE6CC7FRight-Click|r to Sync Join Date with Alts"] = true
     GRM_L["|CFFE6CC7FRight-Click|r to Set Notification of Status Change"] = true
@@ -611,7 +581,6 @@ GRML.SpanishMX = function()
     GRM_L["{name} has been removed from the database."] = true              -- The Guild Name has been removed from the database
 
     -- update 1.141
-    GRM_L["You will still share your data with the guild, but you are currently only accepting incoming changes from rank \"{name}\" or higher"] = true    -- Reminder, the backslash before a quotation denotes the string NOT to close, but to include the quotation in display txt
     GRM_L["Only Restrict Incoming Player Data to Rank Threshold, not Outgoing"] = true
     GRM_L["Total Entries: {num}"] = true
     GRM_L["Search Filter"] = true
@@ -643,9 +612,6 @@ GRML.SpanishMX = function()
 
     -- update 1.145
     GRM_L["You currently are at {num} non-Battletag friends. To fully take advantage of all of GRM features, please consider clearing some room."] = true
-    GRM_L["Clear Space on Friends List to Find Online Status"] = true
-    GRM_L["Offline"] = true
-    GRM_L["{name} has requested to join the guild and is currently ONLINE!"] = true
 
     -- Update 1.146
     GRM_L["Really Clear line {num}?"] = true
@@ -656,7 +622,6 @@ GRML.SpanishMX = function()
     GRM_L["Right-Click to Reset to 100%"] = true
 
     -- Update 1.147
-    GRM_L["|CFFE6CC7FClick|r to open Player Window"] = true
     GRM_L["|CFFE6CC7FCtrl-Shift-Click|r to Search the Log for Player"] = true
 
     -- Update 1.1480
@@ -670,20 +635,15 @@ GRML.SpanishMX = function()
     GRM_L["Sync Custom Notes"] = true
     GRM_L["Default Custom Note Rank Minimum"] = true
     GRM_L["Reset Default Custom Note Restrictions for ALL Guildies"] = true
-    GRM_L["Reset to Default"] = true
     GRM_L["Reset"] = true
     GRM_L["|CFF00CCFFDefault Selection For All Players"] = true
-    GRM_L["If sync was manually disabled for specific guildies, this does NOT enabled it."] = true
-    GRM_L["Custom note Sync has been reset to default"] = true
     GRM_L["Click here to set Custom Notes"] = true
     GRM_L["|CFF00CCFFCustom Note Defaults:"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to re-enable custom note sync for all"] = true
-    GRM_L["Custom Note Sync Disabled in Settings"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Added"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" was Removed"] = true
     GRM_L["{name} modified {name2}'s CUSTOM Note: \"{custom1}\" to \"{custom2}\""] = true
     GRM_L["Custom Note"] = true
-    GRM_L["Syncing Outgoing Data."] = true
     GRM_L["|CFFE6CC7FClick|r to Change Rank Restriction"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Day"] = true
     GRM_L["|CFFE6CC7FClick|r to Change Month"] = true;
@@ -695,7 +655,6 @@ GRML.SpanishMX = function()
     GRM_L["Warning! Ban List rank threshold is below the overall sync rank. Changing from \"{name}\" to \"{name2}\""] = true
     GRM_L["|CFF00CCFFSync filter can be set tighter for the Ban List"] = true
     GRM_L["Warning! Unable to select a Ban List rank below \"{name}\""] = true
-    GRM_L["Warning! Custom Note rank filter must be below \"{name}\""] = true
     GRM_L["Setting to match core filter rank"] = true
 
     -- R1.1482
@@ -704,10 +663,6 @@ GRML.SpanishMX = function()
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Language"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change Display Format"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Change the Font"] = true
-    GRM_L["Unfortunately each player's data will need to be manually reconfigured."] = true
-    GRM_L["{num} custom {custom1} removed that matched text:"] = true                           -- custom1 = "note" or the plural "notes"
-    GRM_L["notes"] = true
-    GRM_L["Please add specific text, in quotations, to match"] = true
 
     -- R1.1490
     GRM_L["You will still share some outgoing data with the guild"] = true
@@ -719,8 +674,6 @@ GRML.SpanishMX = function()
     GRM_L["Use only as an estimate. Hopefully Blizz fixes this soon"] = true
     GRM_L["{name}'s Anniversary!"] = true
     GRM_L["{name}'s Birthday!"] = true
-    GRM_L["Guild member for over {num} year"] = true
-    GRM_L["Guild member for over {num} years"] = true   -- the plural version!
     GRM_L["Add Upcoming Events to the Calendar"] = true
     GRM_L["Player rank unable to add events to calendar"] = true
     GRM_L["Anniversaries, Birthdays, and Other Events can be added with permission"] = true
@@ -729,7 +682,6 @@ GRML.SpanishMX = function()
     GRM_L["Check the \"Sync Users\" tab to find out why!"] = true
     GRM_L["Time as Member:"] = true
     GRM_L["|CFFE6CC7FClick|r to select player event"] = true
-    GRM_L["|CFFE6CC7FClick Again|r to open Player Window"] = true
     GRM_L["Timestamp Format:"] = true
     GRM_L["Hour Format:"] = true
     GRM_L["24 Hour"] = true
@@ -763,31 +715,16 @@ GRML.SpanishMX = function()
     GRM_L["|CFFE6CC7FClick|r to sort Promotion Dates by Oldest"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Mains first"] = true
     GRM_L["|CFFE6CC7FClick|r to sort all Alts first."] = true
-    GRM_L["{name}'s Profile is Being Built. One Moment..."] = true
-    GRM_L["There are {num} players requesting to join your guild. You only have room for {custom1} more friends. Please consider cleaning up your friend and recruitment lists."] = true;
     GRM_L["{name}'s Alts"] = true                                   -- Like "Arkaan's Alts"
-    GRM_L["Online:  {num}/{custom1}"] = true                         -- As in "Online: 3/59"
-    GRM_L["Next"] = true                                            -- This means to Advance forward to the "next" one. It is used on recruitment window to move to NEXT online player.
-    GRM_L["Previous"] = true                                        -- Same context as the "next" except this one goes back to the one before.
-    GRM_L["There are currently no ONLINE recruits."] = true
-    GRM_L["There are currently no more players in that direction."] = true
-    GRM_L["You have reached the end of the list"] = true
-    GRM_L["You have reached the top of the list"] = true
-    GRM_L["Auto Open Window"] = true
-    GRM_L["Only if a player is online and you are not in combat"] = true
-    GRM_L["Recruit window will open when combat ends."] = true
     GRM_L["GRM window will open when combat ends."] = true
 
     -- R1.24
     GRM_L["This also will change the <Alt> format to match"] = true
     GRM_L["M"] = true                                           -- Of note, the "M" is short for "Main" and this is the reference to the main tag on alts in guild chat. For use in the Main tagging <M> (M) etc...
     GRM_L["A"] = true           
-    GRM_L["<M>"] = true                                         -- <M> appears for "Main"
-    GRM_L["<A>"] = true                                         -- This is the "Alt" tag on the Add Alt side window. For use in the Alt tagging <A> (A) etc...
 
     -- R1.25
     GRM_L["Include \"Joined:\" tag with the date."] = true                                          -- the \" is so you include the qutoations in the actual text. You need them or it closes the phrase.
-    GRM_L["Joined: {name}"] = true                                                                  -- {name} is actually in reference to the Data Format... So "Joined: 22 May '18"   {name} = "22 May '18"
     GRM_L["GRM Auto-Detect! {name} has joined the guild and will be set as Main"] = true            -- Main auto-detect message
 
     -- R1.26
@@ -806,30 +743,15 @@ GRML.SpanishMX = function()
     GRM_L["Show Public, Officer, and Custom Notes on Log Entries of Left Players"] = true
     GRM_L["Hard Reset"] = true
     GRM_L["Hard reset of ALL GRM data, account-wide. Game will reload!"] = true
-    GRM_L["Reject\nAll"] = true                     -- This is the same as "Reject All" it just forces the 2 words to be on 2 separate lines without me adjusting the text width
-    GRM_L["{num} Applicants to the Guild have been denied"] = true
-    GRM_L["Do you really want to reject all applicants?"] = true
     GRM_L["Only recommend to kick if all player linked alts exceed max time"] = true
     GRM_L["Your Guild Leader Has Set Sync Restrictions to {name} or Higher"] = true
     GRM_L["Unable to Change Rank. Guild Leader has set restriction to {name} or higher"] = true     -- Like Initiate or higher
     GRM_L["Unable to Change Rank. Guild Leader has set restriction level."] = true
-    GRM_L["Unify Control Settings for all guildies with 'g#^X' commands"] = true
-    GRM_L["CONTROL TAGS:"] = true
     GRM_L["Force Settings with Guild Info Tags"] = true
-    GRM_L["X = index of minimum rank. Example: 0 = {name} and {num} = {name2}"] = true
-    GRM_L["'g2^X' - Establish minimum sync rank restriction for player details"] = true
-    GRM_L["'g3^X' - Establish minimum sync rank restriction for BAN info"] = true
-    GRM_L["'g4^X' - Establish minimum sync rank restriction for Custom Note info"] = true
     GRM_L["Warning! System messages are disabled! GRM cannot function fully without them. You must re-enable them in the chat settings."] = true
     GRM_L["Database Still Loading. GRM will open automatically when finished."] = true
 
     -- R1.29
-    GRM_L["Do you really want to invite all applicants?"] = true
-    GRM_L["There are currently 0 players online to invite."] = true
-    GRM_L["It appears all players are now offline."] = true
-    GRM_L["Invite\nAll"] = true                             -- Just makes it 2 lines - they \n is the line break. You can remove if not necessary, or include.
-    GRM_L["Include Message When Sending Invite"] = true
-    GRM_L["Click here to set custom invite message. Press Enter to save before sending invite!"] = true
     GRM_L["The highlighted character is not valid for messages. Please remove."] = true
     GRM_L["Not all characters are valid. Please remove any non-text characters."] = true
     GRM_L["Kick macro created. Press \"CTRL-SHIFT-K\" to kick all of {name}'s alts"] = true
@@ -840,7 +762,6 @@ GRML.SpanishMX = function()
 
     -- R1.30
     GRM_L["Sync With {name} is Complete..."] = true
-    GRM_L["Database Still Loading. Please Wait..."] = true
     GRM_L["|CFFE6CC7FLeft-Click|r and drag to move this button."] = true
     GRM_L["|CFFE6CC7FCtrl-Left-Click|r and drag to move this button anywhere."] = true
     GRM_L["MOTD:"] = true       -- Message Of The Day = M.O.T.D = MOTD - 
@@ -850,15 +771,12 @@ GRML.SpanishMX = function()
     GRM_L["Show 'Main' Tag on both Mains and Alts in Chat"] = true
 
     -- R1.32
-    GRM_L["Invites Currently Being Sent..."] = true
     GRM_L["GRM has moved the Guild Leader setting restriction codes to the Guild Info tab."] = true
     GRM_L["Please make room for them and re-add."] = true
-    GRM_L["Your Guild Leader has pushed a reset of your data."] = true;
     GRM_L["Your Guild Leader Has Set BAN Sync Restrictions to {name} or Higher"] = true
     GRM_L["Your Guild Leader Has Set CUSTOM NOTE Sync Restrictions to {name} or Higher"] = true
 
     -- R1.33
-    GRM_L["Invite all macro created. Press \"CTRL-SHIFT-K\" to invite all online recruits."] = true
     GRM_L["Macro will auto-remove after {num} seconds."] = true
     GRM_L["UI"] = true
     GRM_L["UI Controls"] = true
@@ -924,12 +842,10 @@ GRML.SpanishMX = function()
     -- R1.41
     GRM_L["{num} metadata profiles are being built for people previously in the guild. The data is being requested, but this may take some time."] = true                   -- PLURAL
     GRM_L["One metadata profile is being built for a player previously in the guild. The data is being requested, but this may take some time."] = true           -- SINGULAR, same line.
-    GRM_L["Sync will re-trigger one time, in a moment, to collect final data on these profiles."] = true
     GRM_L["Auto-Focus the search box"] = true
     GRM_L["This will skip the first time if set to load on logon"] = true  -- Referring to the auto-focusing on the search box, this is a tooltip helper
     GRM_L["Please enter a valid level between 1 and {num}"] = true
     GRM_L["Player's Main: {name}"] = true
-    GRM_L["Player's main no longer in the guild: {name}"] = true
    
     -- R1.43
     GRM_L["One moment, requesting additional details on {name} from the server. Ban List will soon update."] = true
@@ -965,7 +881,6 @@ GRML.SpanishMX = function()
     
     -- 1.56
     -- More slash commands
-    GRM_L["recruits"] = true 
     GRM_L["kick"] = true
     GRM_L["ban"] = true
     GRM_L["audit"] = true
@@ -1003,7 +918,6 @@ GRML.SpanishMX = function()
     GRM_L["|CFFE6CC7FShift-Click|r Second Button to Select All In-Between"] = true
     GRM_L["|CFFE6CC7FClick|r to select player"] = true
     GRM_L["|CFFE6CC7FCtrl-Click|r to open Player Window"] = true
-    GRM_L["Please manually select your guild in the Community Window for this feature to work"] = true
     GRM_L["Only Show Players With Incomplete Status"] = true
     GRM_L["{num} Join Dates Need Attention"] = true             -- In other words, "155 join dates need attention" as an example
     GRM_L["Do you really want to remove the join dates from notes other than the {name}?"] = true
@@ -1043,16 +957,12 @@ GRML.SpanishMX = function()
 
     -- 1.57
     GRM_L["Full Log Message:"] = true
-    GRM_L["Public Notes"] = true
-    GRM_L["Officer Notes"] = true
-    GRM_L["Custom Notes"] = true
     GRM_L["Log Entry Tooltip"] = true
     GRM_L["1 entry has been removed from the log"] = true
     GRM_L["{num} entries have been removed from the log"] = true
     
     -- 1.58
     GRM_L["|CFFE6CC7FCtrl-Click|r to open the Old Guild Roster Window"] = true
-    GRM_L["Using the Old Guild Roster Interface instead"] = true
     
     -- 1.59
     GRM_L["Adding the Join Date cannot be disabled due to the global setting"] = true
@@ -1105,8 +1015,6 @@ GRML.SpanishMX = function()
     GRM_L["No Current Names to Add"] = true
     GRM_L["No Names to Add to the Macro"] = true
     GRM_L["Hot Key: {name}"] = true
-    GRM_L["Press the Hot-key 1 time to complete all actions"] = true
-    GRM_L["Press the Hot-key {num} times to complete all actions"] = true
     GRM_L["Permissions"] = true
     GRM_L["Player rank change detected, re-checking permissions and rebuilding GRM Macro Tool."] = true
     GRM_L["Click to remove selected names from the macro"] = true           -- Plural form of statement
@@ -1169,7 +1077,6 @@ GRML.SpanishMX = function()
     -- CLASSIC
     GRM_L["Social"] = true
     GRM_L["Roster"] = true
-    GRM_L["|CFFE6CC7FCtrl-Click|r to open the Guild Roster Window"] = true
     GRM_L["Feature is disabled in WoW Classic"] = true
     GRM_L["Feature is disabled in TBC Classic"] = true          -- Just laying groundwork now in case Blizz ever releases it. Calendar was not added until WOTLK
     GRM_L["There is no calendar to add events to"] = true
@@ -1210,9 +1117,7 @@ GRML.SpanishMX = function()
     GRM_L["!note"] = true               -- !note in English will always work. This gives you the option of creating your own key to register a public note.
     GRM_L["No officer online to set {name}'s note"] = true
     GRM_L["No officer is currently online to update your note"] = true
-    GRM_L["Note updated by @{name}"] = true              -- As in "Note updated by @Arkaan"
     GRM_L["Allow Guild Members to Type \"!note\" to Set Their Own Public Note"] = true
-    GRM_L["'!note' trigger has been globally enabled"] = true
     GRM_L["Enabled"] = true         -- As in, the opposite of Disabled
     GRM_L["'!note' trigger has been globally ENABLED"] = true
     GRM_L["'!note' trigger has been globally DISABLED"] = true
@@ -1243,7 +1148,6 @@ GRML.SpanishMX = function()
 	GRM_L["*Max Export is 500 Log Entries at a Time"] = true
 	GRM_L["*Max Export is 500 Members at a Time"] = true
 	GRM_L["*Max Export is 500 Former Members at a Time"] = true
-	GRM_L["Log export follows the search and display settings"] = true
 	GRM_L["*Export obeys the current log display filters"] = true
 	GRM_L["Select Line Range:"] = true
 	GRM_L["Select Member Range:"] = true
@@ -1314,7 +1218,6 @@ GRML.SpanishMX = function()
 
      -- 1.84
      GRM_L["The note is too long. Only the first {num} characters will be set."] = true
-     GRM_L["{name} Rule {num}"] = true
      GRM_L["Apply Only to Selected Ranks"] = true
      GRM_L["Unable to create hotkey macro. Player is currently in combat and action is restricted. It will auto-build once out of combat."] = true
      GRM_L["No player data found, recommend full removal."] = true
@@ -1337,7 +1240,6 @@ GRML.SpanishMX = function()
      GRM_L["Join Header"] = true;
      GRM_L["ReJoin Header"] = true;
      GRM_L["!note Control"] = true
-     GRM_L["(default)"] = true           -- as in, this setting is the DEFAULT setting.  Setting (default)
      GRM_L["You need to clear {num} characters to fit the control tags"] = true
      GRM_L["A new format exists for global settings controls."] = true
      GRM_L["Go to GRM window > Options > Officer Tab > \"Set Global Controls\""] = true
@@ -1368,7 +1270,6 @@ GRML.SpanishMX = function()
     
     -- R1.87
     GRM_L["Kick Rule {num}"] = true         -- Exampe: Kick Rule 1
-    GRM_L["Edit Custom Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Disable Rule"] = true
     GRM_L["|CFFE6CC7FLeft-Click|r to Enable Rule"] = true
     GRM_L["Edit"] = true
@@ -1394,7 +1295,6 @@ GRML.SpanishMX = function()
     GRM_L["Note match: {name}"] = true                                  -- Same
     GRM_L["Matching Rank"] = true                                       -- ''
     GRM_L["Right-Click|r to Edit or Remove custom rule"] = true         -- Please keep the '|r' immediately after the click info - as it indicates a text color change point
-    GRM_L["{name} matches the paramaters of {num} of your macro tool rules. Kick Recommended!"] = true
     GRM_L["|CFFE6CC7FClick|r to Change"] = true
     GRM_L["(Applies Only to Classic)"] = true           -- For the Options... rather than removing them all
     
@@ -1422,7 +1322,6 @@ GRML.SpanishMX = function()
     GRM_L["Enable Module"] = true
     GRM_L["Show Interactable Distance Indicator"] = true
     GRM_L["No GRM Modules Currently Installed"] = true
-    GRM_L["Recruitment"] = true
     GRM_L["Pending Feature"] = true
     GRM_L["Custom Color"] = true
     GRM_L["{name} is listed as the Main"] = true
@@ -1483,7 +1382,6 @@ GRML.SpanishMX = function()
     GRM_L["Notify if at Rank for {num} {name}"] = true      -- "Notify if at Rank for 30 Days" or "Notify if at Rank for 12 Months" 
     GRM_L["Player Guild Rep is"] = true         -- Ex: "Player Guild Rep is < Honored" or "Player Guild Rep is = Neutral"  -- Dropdown selection options immediately follow this line. If ordering of boxes before the line would be better, please inform me and I can accomadate your localization efforts
     GRM_L["|CFFE6CC7FClick|r to Change Rep"] = true
-    GRM_L["Guild Rep: {name}"] = true
     GRM_L["Guild Rep:"] = true
     GRM_L["Guild Rep lower than {name}"] = true
     GRM_L["Guild Rep equal to {name}"] = true


### PR DESCRIPTION
I've created a little application which does following things:
* Loads the code base, i.e. `.lua` files in the top directory as string into memory
* Iterate through locales files located in `/locales`
* Extract translations keys from locales file via Regex (pattern: `^\s*(GRM_L\[\".*?\"\])( = )(\".*?\"|true)`)
* Replace `GRM_L[` and the closing bracked with an empty string
* Do a string.Contains() on the code base (i.e. if the extracted key is somehow used e.g. as a comment, it will return true, so the key is being used)
* Remove all unused lines from locales files

I've checked the findings and they don't seem to contain dynamic data. (e.g. month names)