### PR TITLE
Fix nil reference when GRM.S() is unavailable on first load

### DIFF
--- a/GRM_ScanRoster.lua
+++ b/GRM_ScanRoster.lua
@@ -2615,18 +2615,21 @@ Scan.FinalReportInformation = function(needToReport)
     Scan.ResetTempLogs();
 
     if GRM_G.OnFirstLoad then
-        if GRM.S().viewOnLoad then
-            if GRM.S().onlyViewIfChanges and GRM_G.ChangesFoundOnLoad then
-                GRM_UI.GRM_RosterChangeLogFrame:Show();
+        local S = (type(GRM.S) == "function") and GRM.S() or GRM.S
+        if S and S.viewOnLoad then
+            if (not S.onlyViewIfChanges) or GRM_G.ChangesFoundOnLoad then
+                if GRM_UI and GRM_UI.GRM_RosterChangeLogFrame then
+                    GRM_UI.GRM_RosterChangeLogFrame:Show()
+                end
             end
         end
 
-        -- Let's do an announcement
-        Scan.AnnounceIfBirthday();
-        Scan.CheckForDeadAccounts(false);
-        GRM.Util.WarnTableSize();
-        GRM.Prof.AutoStartProfessionUpdate();
-    end
+    Scan.AnnounceIfBirthday()
+    Scan.CheckForDeadAccounts(false)
+    GRM.Util.WarnTableSize()
+    GRM.Prof.AutoStartProfessionUpdate()
+end
+
 
     GRM_UI.RefreshSelectFrames(needToReport, true, false, false, true, (#GRM_G.TempEventReport > 0));
 


### PR DESCRIPTION
This PR prevents a Lua error during the first load of Guild Roster Manager:

`1x ...rfaceGuild_Roster_Manager/GRM_ScanRoster.lua:2607: attempt to index a nil value
[Guild_Roster_Manager/GRM_ScanRoster.lua]:2607: in function 'FinalReportInformation'
[Guild_Roster_Manager/GRM_ScanRoster.lua]:2487: in function <...rfaceGuild_Roster_Manager/GRM_ScanRoster.lua:2485>
`

Cause

When GRM_G.OnFirstLoad is true, the code attempts to access:

`if GRM.S().viewOnLoad then`

However, on first load the saved variable or settings function GRM.S() may return nil, causing attempt to index a nil value.

Fix

Adds a local guard to ensure GRM.S() returns a valid table before indexing fields:

`if GRM_G.OnFirstLoad then  
    local S = (type(GRM.S) == "function") and GRM.S() or GRM.S  
    if S and S.viewOnLoad then  
        if (not S.onlyViewIfChanges) or GRM_G.ChangesFoundOnLoad then  
            if GRM_UI and GRM_UI.GRM_RosterChangeLogFrame then  
                GRM_UI.GRM_RosterChangeLogFrame:Show()  
            end  
        end  
    end
    Scan.AnnounceIfBirthday()  
    Scan.CheckForDeadAccounts(false)  
    GRM.Util.WarnTableSize()  
    GRM.Prof.AutoStartProfessionUpdate()  
end  
`

Result

Prevents crashes at line 2607 on first login or after clean installs.

Preserves existing behavior once settings are initialized.

Adds defensive coding for better addon stability.